### PR TITLE
Added `watch` option to re-run the linters when a file changes ⌚️

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "chalk": "5.3.0",
+    "chokidar": "3.6.0",
     "commander": "12.1.0",
     "eslint": "9.4.0",
     "glob": "10.4.1",

--- a/src/__tests__/watchFiles.spec.ts
+++ b/src/__tests__/watchFiles.spec.ts
@@ -43,6 +43,7 @@ describe('watchFiles', () => {
 
     expect(chokidar.watch).toHaveBeenCalledWith(filePatterns, {
       ignored: ignorePatterns,
+      ignoreInitial: true,
       persistent: true,
     })
   })

--- a/src/__tests__/watchFiles.spec.ts
+++ b/src/__tests__/watchFiles.spec.ts
@@ -47,11 +47,11 @@ describe('watchFiles', () => {
     })
   })
 
-  it('emits a "FILE_CHANGED" event when saving the file for the first time', done => {
+  it('emits a "FILE_CHANGED" event when saving an existing file (because there is no hash map yet)', done => {
     expect.assertions(1)
 
     const mockPath = 'mock/existing-file.ts'
-    mockReadFile('first-time-save')
+    mockReadFile('open-and-save')
 
     fileChangeEvent.on(Events.FILE_CHANGED, params => {
       expect(params).toStrictEqual({

--- a/src/__tests__/watchFiles.spec.ts
+++ b/src/__tests__/watchFiles.spec.ts
@@ -1,0 +1,111 @@
+import { readFile } from 'fs'
+
+import chokidar from 'chokidar'
+
+import { Events } from '@Types'
+
+import { fileChangeEvent, watchFiles } from '../watchFiles'
+
+jest.mock('fs')
+jest.mock('chokidar')
+
+describe('watchFiles', () => {
+  let mockWatcher: chokidar.FSWatcher
+
+  const mockReadFile = (content: string) => {
+    jest.mocked(readFile).mockImplementationOnce((_path: any, _encoding: any, callback?: (error: any, data: any) => void): void => {
+      if (callback) {
+        callback(null, content)
+      }
+    })
+  }
+
+  beforeEach(() => {
+    mockWatcher = {
+      add: jest.fn(),
+      close: jest.fn(),
+      on: jest.fn(),
+      unwatch: jest.fn(),
+    } as unknown as chokidar.FSWatcher
+
+    jest.mocked(chokidar.watch).mockReturnValue(mockWatcher)
+  })
+
+  afterEach(() => {
+    fileChangeEvent.removeAllListeners()
+  })
+
+  it('initialises chokidar with the correct file and ignore patterns', () => {
+    const filePatterns = ['**/*.ts']
+    const ignorePatterns = ['node_modules']
+
+    watchFiles({ filePatterns, ignorePatterns })
+
+    expect(chokidar.watch).toHaveBeenCalledWith(filePatterns, {
+      ignored: ignorePatterns,
+      persistent: true,
+    })
+  })
+
+  it('emits a "FILE_CHANGED" event when saving the file for the first time', done => {
+    expect.assertions(1)
+
+    const mockPath = 'mock/new-file.ts'
+    mockReadFile('first-time-save')
+
+    fileChangeEvent.on(Events.FILE_CHANGED, path => {
+      expect(path).toBe(mockPath)
+      done()
+    })
+
+    watchFiles({ filePatterns: [mockPath], ignorePatterns: [] })
+
+    const changeHandler = (mockWatcher.on as jest.Mock).mock.calls.find(call => call[0] === 'change')[1]
+    changeHandler(mockPath)
+  })
+
+  it('emits a "FILE_CHANGED" event if the file content changes', done => {
+    expect.assertions(2)
+
+    const mockPath = 'mock/old-file.ts'
+    mockReadFile('old-content')
+
+    fileChangeEvent.on(Events.FILE_CHANGED, path => {
+      expect(path).toBe(mockPath)
+    })
+
+    watchFiles({ filePatterns: [mockPath], ignorePatterns: [] })
+
+    const changeHandler = (mockWatcher.on as jest.Mock).mock.calls.find(call => call[0] === 'change')[1]
+    changeHandler(mockPath)
+
+    mockReadFile('new-content')
+    changeHandler(mockPath)
+
+    setTimeout(() => {
+      done()
+    }, 100)
+  })
+
+  it('does not emit a "FILE_CHANGED" event if the file content did not change', done => {
+    expect.assertions(1)
+
+    const mockPath = 'mock/old-file.ts'
+    mockReadFile('old-content')
+
+    fileChangeEvent.on(Events.FILE_CHANGED, path => {
+      expect(path).toBe(mockPath)
+    })
+
+    watchFiles({ filePatterns: [mockPath], ignorePatterns: [] })
+
+    const changeHandler = (mockWatcher.on as jest.Mock).mock.calls.find(call => call[0] === 'change')[1]
+    changeHandler(mockPath)
+    changeHandler(mockPath)
+    changeHandler(mockPath)
+
+    setTimeout(() => {
+      done()
+    }, 100)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,9 +104,10 @@ program
         ignorePatterns: ['**/+(coverage|node_modules)/**'],
       })
 
-      fileChangeEvent.on(Events.FILE_CHANGED, path => {
+      fileChangeEvent.on(Events.FILE_CHANGED, ({ message }) => {
         clearTerminal()
-        colourLog.info(`File \`${path}\` has been changed.\n`)
+        colourLog.info(message)
+        console.log()
         runLintPilot({ debug, title, watch })
       })
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 import { Command } from 'commander'
 
-import { Linter, type LinterResult } from '@Types'
+import { Events, Linter, type LinterResult } from '@Types'
 import colourLog from '@Utils/colourLog'
 import { notifyResults } from '@Utils/notifier'
+import { clearTerminal } from '@Utils/terminal'
 
 import linters from './linters/index'
 import sourceFiles from './sourceFiles'
+import { fileChangeEvent, watchFiles } from './watchFiles'
 
 const program = new Command()
 
@@ -21,7 +23,14 @@ interface RunLinter {
   linter: Linter
 }
 
+interface RunLintPilot {
+  debug: boolean
+  title: string
+  watch: boolean
+}
+
 const runLinter = async ({ debug, filePattern, linter }: RunLinter) => {
+  // TODO: Handle case where no files are sourced
   const startTime = new Date().getTime()
   colourLog.info(`Running ${linter.toLowerCase()}...`)
 
@@ -39,42 +48,68 @@ const runLinter = async ({ debug, filePattern, linter }: RunLinter) => {
   return result
 }
 
+const runLintPilot = ({ debug, title, watch }: RunLintPilot) => {
+  Promise.all([
+    runLinter({
+      debug,
+      filePattern: '**/*.{cjs,js,jsx,mjs,ts,tsx}',
+      linter: Linter.ESLint,
+    }),
+    runLinter({
+      debug,
+      filePattern: '**/*.{md,mdx}',
+      linter: Linter.Markdownlint,
+    }),
+    runLinter({
+      debug,
+      filePattern: '**/*.{css,scss,less,sass,styl,stylus}',
+      linter: Linter.Stylelint,
+    }),
+  ]).then((results) => {
+    console.log()
+
+    results.forEach(({ processedResult }) => {
+      colourLog.resultBlock(processedResult)
+    })
+
+    const exitCode = notifyResults(results, title)
+
+    if (watch) {
+      colourLog.info('Watching for changes...')
+    } else {
+      process.exit(exitCode)
+    }
+  })
+}
+
 program
   .option('-e, --emoji <string>', 'customise the emoji displayed when running lint-pilot', '✈️')
   .option('-t, --title <string>', 'customise the title displayed when running lint-pilot', 'Lint Pilot')
+  .option('-w, --watch', 'watch for file changes and re-run the linters', false)
   .option('--debug', 'output additional debug information including the list of files being linted', false)
-  .action(({ debug, emoji, title }) => {
-    console.clear()
+  .action(({ debug, emoji, title, watch }) => {
+    clearTerminal()
     colourLog.title(`${emoji} ${title} ${emoji}`)
     console.log()
 
-    Promise.all([
-      runLinter({
-        debug,
-        filePattern: '**/*.{cjs,js,jsx,mjs,ts,tsx}',
-        linter: Linter.ESLint,
-      }),
-      runLinter({
-        debug,
-        filePattern: '**/*.{md,mdx}',
-        linter: Linter.Markdownlint,
-      }),
-      runLinter({
-        debug,
-        filePattern: '**/*.{css,scss,less,sass,styl,stylus}',
-        linter: Linter.Stylelint,
-      }),
-    ]).then((results) => {
-      console.log()
+    runLintPilot({ debug, title, watch })
 
-      results.forEach(({ processedResult }) => {
-        colourLog.resultBlock(processedResult)
+    if (watch) {
+      watchFiles({
+        filePatterns: [
+          '**/*.{cjs,js,jsx,mjs,ts,tsx}',
+          '**/*.{md,mdx}',
+          '**/*.{css,scss,less,sass,styl,stylus}',
+        ],
+        ignorePatterns: ['**/+(coverage|node_modules)/**'],
       })
 
-      const exitCode = notifyResults(results, title)
-
-      process.exit(exitCode)
-    })
+      fileChangeEvent.on(Events.FILE_CHANGED, path => {
+        clearTerminal()
+        colourLog.info(`File \`${path}\` has been changed.\n`)
+        runLintPilot({ debug, title, watch })
+      })
+    }
   })
 
 program.parse(process.argv)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,7 @@
+enum Events {
+  FILE_CHANGED = 'FILE_CHANGED',
+}
+
 enum Linter {
   ESLint = 'ESLint',
   Markdownlint = 'MarkdownLint',
@@ -24,5 +28,6 @@ export type {
 }
 
 export {
+  Events,
   Linter,
 }

--- a/src/utils/__tests__/terminal.spec.ts
+++ b/src/utils/__tests__/terminal.spec.ts
@@ -1,0 +1,14 @@
+import { clearTerminal } from '../terminal'
+
+describe('clearTerminal', () => {
+
+  it('calls process.stdout.write to clear the terminal', () => {
+    const mockWrite = jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    clearTerminal()
+
+    expect(mockWrite).toHaveBeenCalledWith('\x1Bc\x1B[3J\x1B[2J\x1B[H')
+    mockWrite.mockRestore()
+  })
+
+})

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,0 +1,5 @@
+const clearTerminal = () => process.stdout.write('\x1Bc\x1B[3J\x1B[2J\x1B[H')
+
+export {
+  clearTerminal,
+}

--- a/src/watchFiles.ts
+++ b/src/watchFiles.ts
@@ -20,6 +20,7 @@ const getHash = (data: string) => createHash('md5').update(data).digest('hex')
 const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
   const watcher = chokidar.watch(filePatterns, {
     ignored: ignorePatterns,
+    ignoreInitial: true,
     persistent: true,
   })
 

--- a/src/watchFiles.ts
+++ b/src/watchFiles.ts
@@ -1,0 +1,40 @@
+import { createHash } from 'crypto'
+import { EventEmitter } from 'events'
+import { readFile } from 'fs'
+
+import chokidar from 'chokidar'
+
+import { Events } from '@Types'
+
+interface WatchFiles {
+  filePatterns: Array<string>
+  ignorePatterns: Array<string>
+}
+
+const fileChangeEvent = new EventEmitter()
+
+const fileHashes = new Map<string, string>()
+
+const getHash = (data: string) => createHash('md5').update(data).digest('hex')
+
+const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
+  const watcher = chokidar.watch(filePatterns, {
+    ignored: ignorePatterns,
+    persistent: true,
+  })
+
+  watcher.on('change', (path, _stats) => {
+    readFile(path, 'utf8', (_error, data) => {
+      const newHash = getHash(data)
+      if (fileHashes.get(path) !== newHash) {
+        fileHashes.set(path, newHash)
+        fileChangeEvent.emit(Events.FILE_CHANGED, path)
+      }
+    })
+  })
+}
+
+export {
+  fileChangeEvent,
+  watchFiles,
+}

--- a/src/watchFiles.ts
+++ b/src/watchFiles.ts
@@ -23,13 +23,30 @@ const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
     persistent: true,
   })
 
+  watcher.on('add', (path, _stats) => {
+    fileChangeEvent.emit(Events.FILE_CHANGED, {
+      message: `File \`${path}\` has been added.`,
+      path,
+    })
+  })
+
   watcher.on('change', (path, _stats) => {
     readFile(path, 'utf8', (_error, data) => {
       const newHash = getHash(data)
       if (fileHashes.get(path) !== newHash) {
         fileHashes.set(path, newHash)
-        fileChangeEvent.emit(Events.FILE_CHANGED, path)
+        fileChangeEvent.emit(Events.FILE_CHANGED, {
+          message: `File \`${path}\` has been changed.`,
+          path,
+        })
       }
+    })
+  })
+
+  watcher.on('unlink', path => {
+    fileChangeEvent.emit(Events.FILE_CHANGED, {
+      message: `File \`${path}\` has been removed.`,
+      path,
     })
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,7 +1851,7 @@ ansi-styles@^6.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
-anymatch@^3.0.3:
+anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -1980,6 +1980,11 @@ balanced-match@^2.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
   integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
+binary-extensions@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
+  integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1995,7 +2000,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.3:
+braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -2077,6 +2082,21 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+chokidar@3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 ci-info@^3.2.0:
   version "3.9.0"
@@ -2638,7 +2658,7 @@ get-tsconfig@^4.7.5:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -2809,6 +2829,13 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-core-module@^2.13.0:
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
@@ -2836,7 +2863,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -3600,7 +3627,7 @@ node-releases@^2.0.14:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
   integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -3726,7 +3753,7 @@ picocolors@^1.0.0, picocolors@^1.0.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
   integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
 
-picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -3828,6 +3855,13 @@ react-is@^18.0.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
 
 regenerate-unicode-properties@^10.1.0:
   version "10.1.1"


### PR DESCRIPTION
## Details

### What have you changed?

- Added watch option to re-run the linters when a file either changes, is added, or deleted.

### Why are you making these changes?

- Re-running the lint checks when a file changes is a useful feature to engineers. At the stage all files are re-linted when a file is changed. Though this could change;
  - Option 1: Re-lint only the file which changed, and ask the user if they would like to lint all files again after.
    - This would be beneficial to quickly fix a single file and then move onto the next.
  - Option 2: Set up different watchers for the different linters and only re-run the relevant one.
    - This one would provide for a faster feedback loop.
  - The concern with both options is that providing a green success message may be confusing as there may be lint errors in other files which have not been re-linted.
  - Option 3: Keep track of lint errors, update that when a single file is linted again, and display all of the results again.
    - This option requires more work and must not introduce confusing or misleading results.
