### PR TITLE
Configured `markdownlint` to load custom config 🪇

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,6 +1,9 @@
 module.exports = {
   presets: [
-    ["@babel/preset-env", { targets: { node: "current" } }],
-    "@babel/preset-typescript",
+    ['@babel/preset-env', {
+      modules: 'auto',
+      targets: { node: 'current' },
+    }],
+    '@babel/preset-typescript',
   ],
 }

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -6,4 +6,9 @@ module.exports = {
     }],
     '@babel/preset-typescript',
   ],
+  plugins: [
+    ['babel-plugin-transform-import-meta', {
+      module: 'ES6',
+    }]
+  ]
 }

--- a/config/markdownlint.json
+++ b/config/markdownlint.json
@@ -1,0 +1,3 @@
+{
+  "default": true
+}

--- a/jest-config/setup.ts
+++ b/jest-config/setup.ts
@@ -1,0 +1,19 @@
+beforeEach(() => {
+  global.debug = false
+})
+
+expect.extend({
+  toHaveBeenCalledOnceWith(received, ...expected) {
+    const pass = received.mock.calls.length === 1 && received.mock.calls[0].every((arg, index) => {
+      if (typeof arg === 'object' && typeof expected[index] === 'object') {
+        return JSON.stringify(arg) === JSON.stringify(expected[index])
+      }
+      return arg === expected[index]
+    })
+
+    return {
+      message: () => `expected ${received.getMockName()} to have been called exactly once with "${expected}" but received "${received.mock.calls[0]}"`,
+      pass,
+    }
+  },
+})

--- a/jest-config/types.d.ts
+++ b/jest-config/types.d.ts
@@ -1,0 +1,9 @@
+import '@jest/globals'
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveBeenCalledOnceWith(...args: Array<any>): R
+    }
+  }
+}

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,0 +1,3 @@
+beforeEach(() => {
+  global.debug = false
+})

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,3 +1,0 @@
-beforeEach(() => {
-  global.debug = false
-})

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,7 +8,7 @@ const config: JestConfigWithTsJest = {
     'src/**/*.ts',
     // TODO: Write tests for these files when they are less likely to change
     '!src/index.ts',
-    '!src/linters/*.ts',
+    '!src/linters/(eslint|index|stylelint).ts',
   ],
   coverageDirectory: 'coverage',
   coverageThreshold: {
@@ -25,8 +25,11 @@ const config: JestConfigWithTsJest = {
     '^@Utils(.*)$': '<rootDir>/src/utils$1',
   },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest'
+    '^.+\\.(js|ts)$': 'babel-jest',
   },
+  transformIgnorePatterns: [
+    './node_modules/(?!(chalk)/)',
+  ]
 }
 
 export default config

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -24,6 +24,9 @@ const config: JestConfigWithTsJest = {
     '^@Types(.*)$': '<rootDir>/src/types$1',
     '^@Utils(.*)$': '<rootDir>/src/utils$1',
   },
+  setupFilesAfterEnv: [
+    '<rootDir>/jest-setup.ts',
+  ],
   transform: {
     '^.+\\.(js|ts)$': 'babel-jest',
   },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -25,7 +25,7 @@ const config: JestConfigWithTsJest = {
     '^@Utils(.*)$': '<rootDir>/src/utils$1',
   },
   setupFilesAfterEnv: [
-    '<rootDir>/jest-setup.ts',
+    '<rootDir>/jest-config/setup.ts',
   ],
   transform: {
     '^.+\\.(js|ts)$': 'babel-jest',

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/eslint": "8.56.10",
     "@types/jest": "29.5.12",
     "@types/node-notifier": "8.0.5",
+    "babel-plugin-transform-import-meta": "2.2.1",
     "jest": "29.7.0",
     "rimraf": "5.0.7",
     "rollup": "4.18.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "rimraf lib && mkdir lib && rollup -c && yarn buildConfig",
     "buildConfig": "tsx ./scripts/build-config.ts",
-    "lint": "tsx src/index.js",
+    "lint": "NODE_ENV=development tsx src/index.js",
     "publishLib": "yarn test --coverage && yarn build && cd lib && npm publish",
     "test": "jest"
   },
@@ -35,6 +35,7 @@
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
     "@babel/preset-typescript": "7.24.7",
+    "@rollup/plugin-replace": "5.0.7",
     "@rollup/plugin-typescript": "11.1.6",
     "@types/eslint": "8.56.10",
     "@types/jest": "29.5.12",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
+import replace from '@rollup/plugin-replace'
 import typescript from '@rollup/plugin-typescript'
 import { terser } from 'rollup-plugin-terser'
 
@@ -14,6 +15,10 @@ export default {
     format: 'es',
   },
   plugins: [
+    replace({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+      preventAssignment: true,
+    }),
     terser(),
     typescript(),
   ],

--- a/scripts/build-config.ts
+++ b/scripts/build-config.ts
@@ -9,6 +9,14 @@ const outputFolder = './lib'
  * Utilities
  */
 
+const copyFile = async (file: string, filePath: string) => {
+  const destinationPath = path.join(outputFolder, file)
+
+  await fs.promises.copyFile(filePath, destinationPath)
+
+  console.log(`Successfully copied "${file}" to output folder`)
+}
+
 const writeFile = async (filename: string, contents: Record<string, unknown>): Promise<void> => {
   const contentsString = util.inspect(contents, {
     depth: Infinity,
@@ -33,9 +41,14 @@ const compileLintConfiguration = async (): Promise<void> => {
       if ((await fs.promises.stat(filePath)).isFile()) {
         const filename = path.parse(file).name
 
+        if (path.extname(file) === '.json') {
+          await copyFile(file, filePath)
+          continue
+        }
+
         console.log(`Building config from "${file}"`)
 
-        const module = await import(filePath)
+        const module = await import(`../${filePath}`)
         await writeFile(path.join(outputFolder, `${filename}.js`), module.default)
 
         console.log(`Successfully built "${filename}.js"!\n`)
@@ -43,6 +56,7 @@ const compileLintConfiguration = async (): Promise<void> => {
     }
   } catch (error) {
     console.error(`Error: ${error.message}`)
+    process.exit(1)
   }
 }
 
@@ -50,7 +64,7 @@ const compileLintConfiguration = async (): Promise<void> => {
  * Copy Additional Files
  */
 
-const copyFiles = async () => {
+const copyAdditionalFiles = async () => {
   try {
     const files = [
       'package.json',
@@ -58,11 +72,8 @@ const copyFiles = async () => {
     ]
 
     for (const file of files) {
-      const sourcePath = path.resolve(`./${file}`)
-      const destinationPath = path.join(outputFolder, file)
-
-      await fs.promises.copyFile(sourcePath, destinationPath)
-      console.log(`Successfully copied "${file}" to output folder`)
+      const filePath = path.resolve(`./${file}`)
+      await copyFile(file, filePath)
     }
   } catch (error) {
     console.error('An error occurred while copying files:', error)
@@ -76,7 +87,7 @@ const copyFiles = async () => {
 
 const init = async () => {
   await compileLintConfiguration()
-  await copyFiles()
+  await copyAdditionalFiles()
 }
 
 init()

--- a/src/__tests__/sourceFiles.spec.ts
+++ b/src/__tests__/sourceFiles.spec.ts
@@ -1,7 +1,7 @@
 import { glob } from 'glob'
 
-import colourLog from '@Utils/colourLog'
 import { Linter } from '@Types'
+import colourLog from '@Utils/colourLog'
 
 import sourceFiles from '../sourceFiles'
 

--- a/src/__tests__/sourceFiles.spec.ts
+++ b/src/__tests__/sourceFiles.spec.ts
@@ -13,7 +13,6 @@ describe('sourceFiles', () => {
   jest.spyOn(process, 'exit').mockImplementation(() => null as never)
 
   const commonArgs = {
-    debug: false,
     filePattern: '*.ts',
     ignore: 'node_modules',
     linter: Linter.ESLint,
@@ -29,13 +28,12 @@ describe('sourceFiles', () => {
     expect(console.log).not.toHaveBeenCalled()
   })
 
-  it('logs the files sourced if debug is true (single file)', async () => {
+  it('logs the files sourced if global.debug is true (single file)', async () => {
+    global.debug = true
+
     jest.mocked(glob).mockResolvedValue(['file1.ts'])
 
-    const files = await sourceFiles({
-      ...commonArgs,
-      debug: true,
-    })
+    const files = await sourceFiles(commonArgs)
 
     expect(glob).toHaveBeenCalledWith('*.ts', { ignore: 'node_modules' })
     expect(files).toEqual(['file1.ts'])
@@ -43,13 +41,12 @@ describe('sourceFiles', () => {
     expect(console.log).toHaveBeenCalledWith(['file1.ts'])
   })
 
-  it('logs the files sourced if debug is true (multiple files)', async () => {
+  it('logs the files sourced if global.debug is true (multiple files)', async () => {
+    global.debug = true
+
     jest.mocked(glob).mockResolvedValue(['file1.ts', 'file2.ts'])
 
-    const files = await sourceFiles({
-      ...commonArgs,
-      debug: true,
-    })
+    const files = await sourceFiles(commonArgs)
 
     expect(glob).toHaveBeenCalledWith('*.ts', { ignore: 'node_modules' })
     expect(files).toEqual(['file1.ts', 'file2.ts'])
@@ -57,13 +54,12 @@ describe('sourceFiles', () => {
     expect(console.log).toHaveBeenCalledWith(['file1.ts', 'file2.ts'])
   })
 
-  it('logs the files sourced if debug is true (no sourced files)', async () => {
+  it('logs the files sourced if global.debug is true (no sourced files)', async () => {
+    global.debug = true
+
     jest.mocked(glob).mockResolvedValue([])
 
-    const files = await sourceFiles({
-      ...commonArgs,
-      debug: true,
-    })
+    const files = await sourceFiles(commonArgs)
 
     expect(glob).toHaveBeenCalledWith('*.ts', { ignore: 'node_modules' })
     expect(files).toEqual([])

--- a/src/__tests__/sourceFiles.spec.ts
+++ b/src/__tests__/sourceFiles.spec.ts
@@ -10,6 +10,7 @@ jest.mock('glob')
 describe('sourceFiles', () => {
 
   jest.spyOn(colourLog, 'error').mockImplementation(() => {})
+  jest.spyOn(colourLog, 'info').mockImplementation(() => {})
   jest.spyOn(console, 'log').mockImplementation(() => {})
   jest.spyOn(process, 'exit').mockImplementation(() => null as never)
 
@@ -38,7 +39,7 @@ describe('sourceFiles', () => {
 
     expect(glob).toHaveBeenCalledWith('*.ts', { ignore: 'node_modules' })
     expect(files).toEqual(['file1.ts'])
-    expect(console.log).toHaveBeenCalledWith('\nSourced 1 file matching "*.ts" for ESLint:')
+    expect(colourLog.info).toHaveBeenCalledWith('\nSourced 1 file matching "*.ts" for ESLint:')
     expect(console.log).toHaveBeenCalledWith(['file1.ts'])
   })
 
@@ -51,7 +52,7 @@ describe('sourceFiles', () => {
 
     expect(glob).toHaveBeenCalledWith('*.ts', { ignore: 'node_modules' })
     expect(files).toEqual(['file1.ts', 'file2.ts'])
-    expect(console.log).toHaveBeenCalledWith('\nSourced 2 files matching "*.ts" for ESLint:')
+    expect(colourLog.info).toHaveBeenCalledWith('\nSourced 2 files matching "*.ts" for ESLint:')
     expect(console.log).toHaveBeenCalledWith(['file1.ts', 'file2.ts'])
   })
 
@@ -64,16 +65,17 @@ describe('sourceFiles', () => {
 
     expect(glob).toHaveBeenCalledWith('*.ts', { ignore: 'node_modules' })
     expect(files).toEqual([])
-    expect(console.log).toHaveBeenCalledWith('\nSourced 0 files matching "*.ts" for ESLint:')
+    expect(colourLog.info).toHaveBeenCalledWith('\nSourced 0 files matching "*.ts" for ESLint:')
     expect(console.log).toHaveBeenCalledWith([])
   })
 
   it('catches any errors and exists the process', async () => {
-    jest.mocked(glob).mockRejectedValue(new Error('Test error'))
+    const error = new Error('Test error')
+    jest.mocked(glob).mockRejectedValue(error)
 
     await sourceFiles(commonArgs)
 
-    expect(colourLog.error).toHaveBeenCalledWith('An error occurred while trying to source files matching *.ts', new Error('Test error'))
+    expect(colourLog.error).toHaveBeenCalledWith('An error occurred while trying to source files matching *.ts', error)
     expect(process.exit).toHaveBeenCalledWith(1)
   })
 

--- a/src/__tests__/sourceFiles.spec.ts
+++ b/src/__tests__/sourceFiles.spec.ts
@@ -19,7 +19,7 @@ describe('sourceFiles', () => {
     linter: Linter.ESLint,
   }
 
-  it('returns files matching the pattern', async () => {
+  it('returns files matching the file pattern', async () => {
     jest.mocked(glob).mockResolvedValue(['file1.ts', 'file2.ts'])
 
     const files = await sourceFiles(commonArgs)

--- a/src/__tests__/sourceFiles.spec.ts
+++ b/src/__tests__/sourceFiles.spec.ts
@@ -1,5 +1,6 @@
 import { glob } from 'glob'
 
+import colourLog from '@Utils/colourLog'
 import { Linter } from '@Types'
 
 import sourceFiles from '../sourceFiles'
@@ -8,8 +9,8 @@ jest.mock('glob')
 
 describe('sourceFiles', () => {
 
+  jest.spyOn(colourLog, 'error').mockImplementation(() => {})
   jest.spyOn(console, 'log').mockImplementation(() => {})
-  jest.spyOn(console, 'error').mockImplementation(() => {})
   jest.spyOn(process, 'exit').mockImplementation(() => null as never)
 
   const commonArgs = {
@@ -72,7 +73,7 @@ describe('sourceFiles', () => {
 
     await sourceFiles(commonArgs)
 
-    expect(console.error).toHaveBeenCalledWith('An error occurred while trying to source files matching *.ts', new Error('Test error'))
+    expect(colourLog.error).toHaveBeenCalledWith('An error occurred while trying to source files matching *.ts', new Error('Test error'))
     expect(process.exit).toHaveBeenCalledWith(1)
   })
 

--- a/src/__tests__/watchFiles.spec.ts
+++ b/src/__tests__/watchFiles.spec.ts
@@ -71,7 +71,7 @@ describe('watchFiles', () => {
     saveFile(mockPath, 'hello-world', 'change')
   })
 
-  it('emits a "FILE_CHANGED" event if the file content changes', done => {
+  it('emits a "FILE_CHANGED" event when saving a file if the file content changes', done => {
     expect.assertions(2)
 
     const mockPath = 'mock/update-file.ts'
@@ -93,7 +93,7 @@ describe('watchFiles', () => {
     }, 100)
   })
 
-  it('does not emit a "FILE_CHANGED" event if the file content did not change', done => {
+  it('does not emit a "FILE_CHANGED" event when saving a file if the file content did not change', done => {
     expect.assertions(1)
 
     const mockPath = 'mock/unchanged-file.ts'
@@ -116,7 +116,7 @@ describe('watchFiles', () => {
     }, 100)
   })
 
-  it('emits a "FILE_CHANGED" event if a file is added', done => {
+  it('emits a "FILE_CHANGED" event when a new file is added', done => {
     expect.assertions(1)
 
     const mockPath = 'mock/new-file.ts'
@@ -134,7 +134,7 @@ describe('watchFiles', () => {
     saveFile(mockPath, 'new-content', 'add')
   })
 
-  it('emits a "FILE_CHANGED" event if a file is removed', done => {
+  it('emits a "FILE_CHANGED" event when a file is removed', done => {
     expect.assertions(1)
 
     const mockPath = 'mock/legacy-file.ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander'
 
-import { Events, Linter, type LinterResult } from '@Types'
+import { Events, Linter, type LinterResult, type RunLinter, type RunLintPilot } from '@Types'
 import colourLog from '@Utils/colourLog'
 import { notifyResults } from '@Utils/notifier'
 import { clearTerminal } from '@Utils/terminal'
@@ -16,18 +16,8 @@ program
   .name('lint-pilot')
   .description('Lint Pilot: Your co-pilot for maintaining high code quality with seamless ESLint, Stylelint, and MarkdownLint integration.')
   .version('0.0.1')
-
-interface RunLinter {
-  debug: boolean
-  filePattern: string
-  linter: Linter
-}
-
-interface RunLintPilot {
-  debug: boolean
-  title: string
-  watch: boolean
-}
+  .addHelpText('beforeAll', '\n✈️ Lint Pilot ✈️\n')
+  .showHelpAfterError('\n💡 Run `lint-pilot --help` for more information')
 
 const runLinter = async ({ debug, filePattern, linter }: RunLinter) => {
   // TODO: Handle case where no files are sourced

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,8 +52,6 @@ const runLintPilot = ({ title, watch }: RunLintPilot) => {
       linter: Linter.Stylelint,
     }),
   ]).then((results) => {
-    console.log()
-
     results.forEach(({ processedResult }) => {
       colourLog.resultBlock(processedResult)
     })
@@ -63,6 +61,7 @@ const runLintPilot = ({ title, watch }: RunLintPilot) => {
     if (watch) {
       colourLog.info('Watching for changes...')
     } else {
+      console.log()
       process.exit(exitCode)
     }
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,13 +19,12 @@ program
   .addHelpText('beforeAll', '\n✈️ Lint Pilot ✈️\n')
   .showHelpAfterError('\n💡 Run `lint-pilot --help` for more information')
 
-const runLinter = async ({ debug, filePattern, linter }: RunLinter) => {
+const runLinter = async ({ filePattern, linter }: RunLinter) => {
   // TODO: Handle case where no files are sourced
   const startTime = new Date().getTime()
   colourLog.info(`Running ${linter.toLowerCase()}...`)
 
   const files = await sourceFiles({
-    debug,
     filePattern,
     ignore: '**/+(coverage|node_modules)/**',
     linter,
@@ -38,20 +37,17 @@ const runLinter = async ({ debug, filePattern, linter }: RunLinter) => {
   return result
 }
 
-const runLintPilot = ({ debug, title, watch }: RunLintPilot) => {
+const runLintPilot = ({ title, watch }: RunLintPilot) => {
   Promise.all([
     runLinter({
-      debug,
       filePattern: '**/*.{cjs,js,jsx,mjs,ts,tsx}',
       linter: Linter.ESLint,
     }),
     runLinter({
-      debug,
       filePattern: '**/*.{md,mdx}',
       linter: Linter.Markdownlint,
     }),
     runLinter({
-      debug,
       filePattern: '**/*.{css,scss,less,sass,styl,stylus}',
       linter: Linter.Stylelint,
     }),
@@ -82,7 +78,9 @@ program
     colourLog.title(`${emoji} ${title} ${emoji}`)
     console.log()
 
-    runLintPilot({ debug, title, watch })
+    global.debug = debug
+
+    runLintPilot({ title, watch })
 
     if (watch) {
       watchFiles({
@@ -98,7 +96,7 @@ program
         clearTerminal()
         colourLog.info(message)
         console.log()
-        runLintPilot({ debug, title, watch })
+        runLintPilot({ title, watch })
       })
     }
   })

--- a/src/linters/eslint.ts
+++ b/src/linters/eslint.ts
@@ -2,7 +2,7 @@ import { ESLint } from 'eslint'
 
 import { Linter, type LinterResult, type ProcessedResult } from '@Types'
 
-const lintFiles = async (filePaths: Array<string>): Promise<LinterResult> => {
+const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
   try {
     const eslint = new ESLint({
       // @ts-expect-error
@@ -17,7 +17,7 @@ const lintFiles = async (filePaths: Array<string>): Promise<LinterResult> => {
       },
     })
 
-    const results = await eslint.lintFiles(filePaths)
+    const results = await eslint.lintFiles(files)
 
     const processedResult: ProcessedResult = {
       deprecatedRules: [],

--- a/src/linters/index.ts
+++ b/src/linters/index.ts
@@ -2,9 +2,15 @@ import eslint from './eslint'
 import stylelint from './stylelint'
 import markdownlint from './markdownlint'
 
-import { Linter } from '@Types'
+import { Linter, type LinterResult } from '@Types'
 
-const linters = {
+type Linters = {
+  [key in Linter]: {
+    lintFiles: (files: Array<string>) => Promise<LinterResult>
+  }
+}
+
+const linters: Linters = {
   [Linter.ESLint]: eslint,
   [Linter.Markdownlint]: markdownlint,
   [Linter.Stylelint]: stylelint,

--- a/src/linters/markdownlint.ts
+++ b/src/linters/markdownlint.ts
@@ -1,45 +1,80 @@
-import markdownlint, { type LintResults } from 'markdownlint'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
+import markdownlint, { type Configuration, type LintResults } from 'markdownlint'
+
+import colourLog from '@Utils/colourLog'
 import { Linter, type LinterResult, type ProcessedResult } from '@Types'
 
-const lintFiles = (filePaths: Array<string>): Promise<LinterResult> => new Promise((resolve, reject) => {
+const loadConfig = (): [string, Configuration] => {
+  try {
+    // Custom Config
+    const customConfigPath = `${process.cwd()}/markdownlint.json`
+    if (fs.existsSync(customConfigPath)) {
+      return ['custom', markdownlint.readConfigSync(customConfigPath)]
+    }
+
+    const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+    // Local config (if in development mode) - this block will be removed in production builds
+    if (process.env.NODE_ENV === 'development') {
+      const localConfigPath = path.resolve(__dirname, '../../config/markdownlint.json')
+      return ['development', markdownlint.readConfigSync(localConfigPath)]
+    }
+
+    // Local config (if in production mode)
+    const localConfigPath = path.resolve(__dirname, './markdownlint.json')
+    return ['default', markdownlint.readConfigSync(localConfigPath)]
+  } catch (error) {
+    colourLog.error('An error occurred while loading the markdownlint config', error)
+    process.exit(1)
+  }
+}
+
+const lintFiles = (files: Array<string>): Promise<LinterResult> => new Promise((resolve, reject) => {
+  const [configName, config] = loadConfig()
+
+  if (global.debug) {
+    console.log(`Using ${configName} markdownlint config:`, config)
+  }
+
   markdownlint({
-    config: {
-      default: true,
-    },
-    files: filePaths,
+    config,
+    files,
   }, (error: any, results: LintResults | undefined) => {
     if (error) {
-      console.error(error.stack)
-      reject(error)
+      colourLog.error('An error occurred while running markdownlint', error)
+      return reject(error)
     }
 
-    if (results) {
-      const processedResult: ProcessedResult = {
-        deprecatedRules: [],
-        errorCount: 0,
-        fileCount: Object.keys(results).length,
-        fixableErrorCount: 0,
-        fixableWarningCount: 0,
-        linter: Linter.Markdownlint,
-        warningCount: 0,
-      }
-
-      Object.entries(results).forEach(([_file, errors]) => {
-        processedResult.errorCount += errors.length
-        errors.forEach(({ fixInfo }) => {
-          if (fixInfo) {
-            processedResult.fixableErrorCount += 1
-          }
-        })
-      })
-
-      resolve({
-        processedResult,
-      })
+    if (!results) {
+      colourLog.error('An error occurred while running markdownlint: no results')
+      return reject(error)
     }
 
-    // TODO: Throw error if results is undefined
+    const processedResult: ProcessedResult = {
+      deprecatedRules: [],
+      errorCount: 0,
+      fileCount: Object.keys(results).length,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0,
+      linter: Linter.Markdownlint,
+      warningCount: 0,
+    }
+
+    Object.entries(results).forEach(([_file, errors]) => {
+      processedResult.errorCount += errors.length
+      errors.forEach(({ fixInfo }) => {
+        if (fixInfo) {
+          processedResult.fixableErrorCount += 1
+        }
+      })
+    })
+
+    resolve({
+      processedResult,
+    })
   })
 })
 

--- a/src/linters/markdownlint/__tests__/index.spec.ts
+++ b/src/linters/markdownlint/__tests__/index.spec.ts
@@ -1,0 +1,132 @@
+import markdownlint from 'markdownlint'
+
+import colourLog from '@Utils/colourLog'
+
+import markdownLib from '..'
+import loadConfig from '../loadConfig'
+
+jest.mock('markdownlint')
+jest.mock('@Utils/colourLog')
+jest.mock('../loadConfig')
+
+describe('markdownlint', () => {
+
+  jest.spyOn(colourLog, 'info').mockImplementation(() => {})
+  jest.spyOn(console, 'log').mockImplementation(() => {})
+
+  const mockedConfig = { default: true }
+  const testFiles = ['README.md']
+
+  beforeEach(() => {
+    jest.mocked(loadConfig).mockReturnValue(['default', mockedConfig])
+  })
+
+  it('logs the config when global.debug is true', async () => {
+    global.debug = true
+    jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
+      callback(null, {})
+    })
+
+    await markdownLib.lintFiles(testFiles)
+
+    expect(colourLog.info).toHaveBeenCalledWith('\nUsing default markdownlint config:')
+    expect(console.log).toHaveBeenCalledWith(mockedConfig)
+  })
+
+  it('rejects when markdownlint returns an error', async () => {
+    const error = new Error('Test error')
+    jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
+      callback(error, undefined)
+    })
+
+    await expect(markdownLib.lintFiles(testFiles)).rejects.toThrow('Test error')
+    expect(colourLog.error).toHaveBeenCalledWith('An error occurred while running markdownlint', error)
+  })
+
+  it('rejects when markdownlint returns no results', async () => {
+    jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
+      callback(null, undefined)
+    })
+
+    await expect(markdownLib.lintFiles(testFiles)).rejects.toThrow('No results')
+    expect(colourLog.error).toHaveBeenCalledWith('An error occurred while running markdownlint: no results')
+  })
+
+  it('resolves with processed results when markdownlint successfully lints', async () => {
+    const mockedResults = {
+      'README.md': []
+    }
+
+    jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
+      callback(null, mockedResults)
+    })
+
+    const result = await markdownLib.lintFiles(testFiles)
+
+    expect(result).toStrictEqual({
+      processedResult: {
+        deprecatedRules: [],
+        errorCount: 0,
+        fileCount: 1,
+        fixableErrorCount: 0,
+        fixableWarningCount: 0,
+        linter: 'MarkdownLint',
+        warningCount: 0,
+      },
+    })
+  })
+
+  it('counts fixable errors correctly', async () => {
+    const commonError = {
+      ruleNames: ['test-rule'],
+      ruleDescription: 'test-rule-description',
+      ruleInformation: 'test-rule-information',
+      errorDetail: 'test-error-detail',
+      errorContext: 'test-error-context',
+      errorRange: [1, 2],
+    }
+
+    const mockedResults = {
+      'CHANGELOG.md': [{
+        ...commonError,
+        lineNumber: 1,
+        fixInfo: {
+          lineNumber: 1,
+        },
+      }],
+      'CONTRIBUTING.md': [],
+      'README.md': [{
+        ...commonError,
+        lineNumber: 7,
+        fixInfo: {
+          lineNumber: 7,
+        },
+      }, {
+        ...commonError,
+        lineNumber: 13,
+      }, {
+        ...commonError,
+        lineNumber: 18,
+      }],
+    }
+
+    jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
+      callback(null, mockedResults)
+    })
+
+    const result = await markdownLib.lintFiles(testFiles)
+
+    expect(result).toStrictEqual({
+      processedResult: {
+        deprecatedRules: [],
+        errorCount: 4,
+        fileCount: 3,
+        fixableErrorCount: 2,
+        fixableWarningCount: 0,
+        linter: 'MarkdownLint',
+        warningCount: 0,
+      },
+    })
+  })
+
+})

--- a/src/linters/markdownlint/__tests__/loadConfig.spec.ts
+++ b/src/linters/markdownlint/__tests__/loadConfig.spec.ts
@@ -47,6 +47,7 @@ describe('loadConfig', () => {
 
   it('catches and logs any errors', () => {
     const error = new Error('Test error')
+
     jest.mocked(fs.existsSync).mockImplementationOnce(() => {
       throw error
     })

--- a/src/linters/markdownlint/__tests__/loadConfig.spec.ts
+++ b/src/linters/markdownlint/__tests__/loadConfig.spec.ts
@@ -1,0 +1,60 @@
+import fs from 'fs'
+
+import markdownlint from 'markdownlint'
+
+import colourLog from '@Utils/colourLog'
+
+import loadConfig from '../loadConfig'
+
+jest.mock('fs')
+
+describe('loadConfig', () => {
+
+  jest.spyOn(colourLog, 'error').mockImplementation(() => {})
+  jest.spyOn(markdownlint, 'readConfigSync').mockImplementation(() => ({ default: true }))
+  jest.spyOn(process, 'exit').mockImplementation(() => null as never)
+
+  it('returns the custom config if it exists', () => {
+    jest.mocked(fs.existsSync).mockReturnValueOnce(true)
+
+    expect(loadConfig()).toStrictEqual(['custom', {
+      default: true,
+    }])
+    expect(markdownlint.readConfigSync).toHaveBeenCalledWith(`${process.cwd()}/markdownlint.json`)
+  })
+
+  it('returns the development config when NODE_ENV is development', () => {
+    process.env.NODE_ENV = 'development'
+
+    jest.mocked(fs.existsSync).mockReturnValueOnce(false)
+
+    expect(loadConfig()).toStrictEqual(['development', {
+      default: true,
+    }])
+    expect(markdownlint.readConfigSync).toHaveBeenCalledWith(expect.stringContaining('lint-pilot/config/markdownlint.json'))
+  })
+
+  it('returns the default config when NODE_ENV is production', () => {
+    process.env.NODE_ENV = 'production'
+
+    jest.mocked(fs.existsSync).mockReturnValueOnce(false)
+
+    expect(loadConfig()).toStrictEqual(['default', {
+      default: true,
+    }])
+    expect(markdownlint.readConfigSync).toHaveBeenCalledWith(expect.stringContaining('markdownlint/markdownlint.json'))
+  })
+
+  it('catches and logs any errors', () => {
+    const error = new Error('Test error')
+    jest.mocked(fs.existsSync).mockImplementationOnce(() => {
+      throw error
+    })
+
+    loadConfig()
+
+    expect(colourLog.error).toHaveBeenCalledWith('An error occurred while loading the markdownlint config', error)
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+})

--- a/src/linters/markdownlint/index.ts
+++ b/src/linters/markdownlint/index.ts
@@ -9,7 +9,8 @@ const lintFiles = (files: Array<string>): Promise<LinterResult> => new Promise((
   const [configName, config] = loadConfig()
 
   if (global.debug) {
-    console.log(`Using ${configName} markdownlint config:`, config)
+    colourLog.info(`\nUsing ${configName} markdownlint config:`)
+    console.log(config)
   }
 
   markdownlint({
@@ -23,7 +24,7 @@ const lintFiles = (files: Array<string>): Promise<LinterResult> => new Promise((
 
     if (!results) {
       colourLog.error('An error occurred while running markdownlint: no results')
-      return reject(error)
+      return reject(new Error('No results'))
     }
 
     const processedResult: ProcessedResult = {

--- a/src/linters/markdownlint/index.ts
+++ b/src/linters/markdownlint/index.ts
@@ -1,36 +1,9 @@
-import fs from 'fs'
-import path from 'path'
-import { fileURLToPath } from 'url'
-
-import markdownlint, { type Configuration, type LintResults } from 'markdownlint'
+import markdownlint, { type LintResults } from 'markdownlint'
 
 import colourLog from '@Utils/colourLog'
 import { Linter, type LinterResult, type ProcessedResult } from '@Types'
 
-const loadConfig = (): [string, Configuration] => {
-  try {
-    // Custom Config
-    const customConfigPath = `${process.cwd()}/markdownlint.json`
-    if (fs.existsSync(customConfigPath)) {
-      return ['custom', markdownlint.readConfigSync(customConfigPath)]
-    }
-
-    const __dirname = path.dirname(fileURLToPath(import.meta.url))
-
-    // Local config (if in development mode) - this block will be removed in production builds
-    if (process.env.NODE_ENV === 'development') {
-      const localConfigPath = path.resolve(__dirname, '../../config/markdownlint.json')
-      return ['development', markdownlint.readConfigSync(localConfigPath)]
-    }
-
-    // Local config (if in production mode)
-    const localConfigPath = path.resolve(__dirname, './markdownlint.json')
-    return ['default', markdownlint.readConfigSync(localConfigPath)]
-  } catch (error) {
-    colourLog.error('An error occurred while loading the markdownlint config', error)
-    process.exit(1)
-  }
-}
+import loadConfig from './loadConfig'
 
 const lintFiles = (files: Array<string>): Promise<LinterResult> => new Promise((resolve, reject) => {
   const [configName, config] = loadConfig()

--- a/src/linters/markdownlint/index.ts
+++ b/src/linters/markdownlint/index.ts
@@ -1,7 +1,7 @@
 import markdownlint, { type LintResults } from 'markdownlint'
 
-import colourLog from '@Utils/colourLog'
 import { Linter, type LinterResult, type ProcessedResult } from '@Types'
+import colourLog from '@Utils/colourLog'
 
 import loadConfig from './loadConfig'
 

--- a/src/linters/markdownlint/index.ts
+++ b/src/linters/markdownlint/index.ts
@@ -8,10 +8,7 @@ import loadConfig from './loadConfig'
 const lintFiles = (files: Array<string>): Promise<LinterResult> => new Promise((resolve, reject) => {
   const [configName, config] = loadConfig()
 
-  if (global.debug) {
-    colourLog.info(`\nUsing ${configName} markdownlint config:`)
-    console.log(config)
-  }
+  colourLog.configDebug(`Using ${configName} markdownlint config:`, config)
 
   markdownlint({
     config,

--- a/src/linters/markdownlint/loadConfig.ts
+++ b/src/linters/markdownlint/loadConfig.ts
@@ -1,0 +1,34 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import markdownlint, { type Configuration } from 'markdownlint'
+
+import colourLog from '@Utils/colourLog'
+
+const loadConfig = (): [string, Configuration] => {
+  try {
+    // Custom Config
+    const customConfigPath = `${process.cwd()}/markdownlint.json`
+    if (fs.existsSync(customConfigPath)) {
+      return ['custom', markdownlint.readConfigSync(customConfigPath)]
+    }
+
+    const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+    // Local config (if in development mode) - this block will be removed in production builds
+    if (process.env.NODE_ENV === 'development') {
+      const localConfigPath = path.resolve(__dirname, '../../../config/markdownlint.json')
+      return ['development', markdownlint.readConfigSync(localConfigPath)]
+    }
+
+    // Local config (if in production mode)
+    const localConfigPath = path.resolve(__dirname, './markdownlint.json')
+    return ['default', markdownlint.readConfigSync(localConfigPath)]
+  } catch (error) {
+    colourLog.error('An error occurred while loading the markdownlint config', error)
+    process.exit(1)
+  }
+}
+
+export default loadConfig

--- a/src/linters/stylelint.ts
+++ b/src/linters/stylelint.ts
@@ -2,7 +2,7 @@ import stylelint from 'stylelint'
 
 import { Linter, type LinterResult, type ProcessedResult } from '@Types'
 
-const lintFiles = async (filePaths: Array<string>): Promise<LinterResult> => {
+const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
   try {
     const { results, ruleMetadata } = await stylelint.lint({
       allowEmptyInput: true,
@@ -11,7 +11,7 @@ const lintFiles = async (filePaths: Array<string>): Promise<LinterResult> => {
           'declaration-block-no-duplicate-properties': true,
         },
       },
-      files: filePaths,
+      files,
     })
 
     const processedResult: ProcessedResult = {

--- a/src/sourceFiles.ts
+++ b/src/sourceFiles.ts
@@ -14,7 +14,7 @@ const sourceFiles = async ({ filePattern, ignore, linter }: SourceFiles) => {
   try {
     const files = await glob(filePattern, { ignore })
     if (global.debug) {
-      console.log(`\nSourced ${files.length} ${pluralise('file', files.length)} matching "${filePattern}" for ${linter}:`)
+      colourLog.info(`\nSourced ${files.length} ${pluralise('file', files.length)} matching "${filePattern}" for ${linter}:`)
       console.log(files)
     }
     return files

--- a/src/sourceFiles.ts
+++ b/src/sourceFiles.ts
@@ -4,16 +4,15 @@ import { Linter } from '@Types'
 import { pluralise } from '@Utils/transform'
 
 interface SourceFiles {
-  debug: boolean
   filePattern: string
   ignore: string
   linter: Linter
 }
 
-const sourceFiles = async ({ debug, filePattern, ignore, linter }: SourceFiles) => {
+const sourceFiles = async ({ filePattern, ignore, linter }: SourceFiles) => {
   try {
     const files = await glob(filePattern, { ignore })
-    if (debug) {
+    if (global.debug) {
       console.log(`\nSourced ${files.length} ${pluralise('file', files.length)} matching "${filePattern}" for ${linter}:`)
       console.log(files)
     }

--- a/src/sourceFiles.ts
+++ b/src/sourceFiles.ts
@@ -13,10 +13,7 @@ interface SourceFiles {
 const sourceFiles = async ({ filePattern, ignore, linter }: SourceFiles) => {
   try {
     const files = await glob(filePattern, { ignore })
-    if (global.debug) {
-      colourLog.info(`\nSourced ${files.length} ${pluralise('file', files.length)} matching "${filePattern}" for ${linter}:`)
-      console.log(files)
-    }
+    colourLog.configDebug(`Sourced ${files.length} ${pluralise('file', files.length)} matching "${filePattern}" for ${linter}:`, files)
     return files
   } catch (error) {
     colourLog.error(`An error occurred while trying to source files matching ${filePattern}`, error)

--- a/src/sourceFiles.ts
+++ b/src/sourceFiles.ts
@@ -1,5 +1,6 @@
 import { glob } from 'glob'
 
+import colourLog from '@Utils/colourLog'
 import { Linter } from '@Types'
 import { pluralise } from '@Utils/transform'
 
@@ -18,7 +19,7 @@ const sourceFiles = async ({ filePattern, ignore, linter }: SourceFiles) => {
     }
     return files
   } catch (error) {
-    console.error(`An error occurred while trying to source files matching ${filePattern}`, error)
+    colourLog.error(`An error occurred while trying to source files matching ${filePattern}`, error)
     process.exit(1)
   }
 }

--- a/src/sourceFiles.ts
+++ b/src/sourceFiles.ts
@@ -1,7 +1,7 @@
 import { glob } from 'glob'
 
-import colourLog from '@Utils/colourLog'
 import { Linter } from '@Types'
+import colourLog from '@Utils/colourLog'
 import { pluralise } from '@Utils/transform'
 
 interface SourceFiles {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  var debug: boolean
+}
+
+export {}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,13 +35,11 @@ interface LinterResult {
  */
 
 interface RunLinter {
-  debug: boolean
   filePattern: string
   linter: Linter
 }
 
 interface RunLintPilot {
-  debug: boolean
   title: string
   watch: boolean
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,7 @@
+/*
+ * ENUMS
+ */
+
 enum Events {
   FILE_CHANGED = 'FILE_CHANGED',
 }
@@ -7,6 +11,10 @@ enum Linter {
   Markdownlint = 'MarkdownLint',
   Stylelint = 'Stylelint',
 }
+
+/*
+ * LINT RESULTS
+ */
 
 interface ProcessedResult {
   deprecatedRules: Array<string>
@@ -22,9 +30,31 @@ interface LinterResult {
   processedResult: ProcessedResult
 }
 
+/*
+ * LINT PILOT
+ */
+
+interface RunLinter {
+  debug: boolean
+  filePattern: string
+  linter: Linter
+}
+
+interface RunLintPilot {
+  debug: boolean
+  title: string
+  watch: boolean
+}
+
+/*
+ * EXPORT
+ */
+
 export type {
   LinterResult,
   ProcessedResult,
+  RunLinter,
+  RunLintPilot,
 }
 
 export {

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 
-import { Linter } from '@Types'
+import { Linter, type ProcessedResult } from '@Types'
 
 import colourLog from '../colourLog'
 
@@ -34,22 +34,22 @@ describe('colourLog', () => {
       colourLog.config('setting', ['foo'])
 
       expect(chalk.magenta).toHaveBeenCalledTimes(1)
-      expect(chalk.magenta).toHaveBeenCalledWith('setting:')
+      expect(chalk.magenta).toHaveBeenCalledWith('setting: ')
       expect(chalk.dim).toHaveBeenCalledTimes(1)
       expect(chalk.dim).toHaveBeenCalledWith('foo')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('setting:', 'foo')
+      expect(mockedConsoleLog).toHaveBeenCalledWith('setting: ', 'foo')
     })
 
     it('logs the key in magenta and the config array in dim', () => {
       colourLog.config('setting', ['foo', 'bar', 'baz'])
 
       expect(chalk.magenta).toHaveBeenCalledTimes(1)
-      expect(chalk.magenta).toHaveBeenCalledWith('setting:')
+      expect(chalk.magenta).toHaveBeenCalledWith('setting: ')
       expect(chalk.dim).toHaveBeenCalledTimes(1)
       expect(chalk.dim).toHaveBeenCalledWith('[foo, bar, baz]')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('setting:', '[foo, bar, baz]')
+      expect(mockedConsoleLog).toHaveBeenCalledWith('setting: ', '[foo, bar, baz]')
     })
 
   })
@@ -69,7 +69,7 @@ describe('colourLog', () => {
 
   describe('result', () => {
 
-    const commonResult = {
+    const commonResult: ProcessedResult = {
       deprecatedRules: [],
       errorCount: 0,
       fileCount: 1,
@@ -79,7 +79,8 @@ describe('colourLog', () => {
       warningCount: 0,
     }
 
-    const now = new Date().getTime()
+    const startTime = new Date().getTime()
+    jest.advanceTimersByTime(1000)
 
     const expectResult = () => {
       expect(chalk.cyan).toHaveBeenCalledWith('Finished eslint')
@@ -90,8 +91,7 @@ describe('colourLog', () => {
     }
 
     it('logs the finished lint message along with the file count and duration (single file)', () => {
-      jest.advanceTimersByTime(1000)
-      colourLog.result(commonResult, now)
+      colourLog.result(commonResult, startTime)
 
       expect(chalk.cyan).toHaveBeenCalledTimes(1)
       expect(chalk.cyan).toHaveBeenCalledWith('Finished eslint')
@@ -106,7 +106,7 @@ describe('colourLog', () => {
       colourLog.result({
         ...commonResult,
         fileCount: 7,
-      }, now)
+      }, startTime)
 
       expect(chalk.cyan).toHaveBeenCalledTimes(1)
       expect(chalk.cyan).toHaveBeenCalledWith('Finished eslint')
@@ -121,7 +121,7 @@ describe('colourLog', () => {
       colourLog.result({
         ...commonResult,
         errorCount: 1,
-      }, now)
+      }, startTime)
 
       expectResult()
       expect(chalk.red).toHaveBeenCalledWith('  1 error')
@@ -132,7 +132,7 @@ describe('colourLog', () => {
       colourLog.result({
         ...commonResult,
         errorCount: 2,
-      }, now)
+      }, startTime)
 
       expectResult()
       expect(chalk.red).toHaveBeenCalledWith('  2 errors')
@@ -144,7 +144,7 @@ describe('colourLog', () => {
         ...commonResult,
         errorCount: 3,
         fixableErrorCount: 2,
-      }, now)
+      }, startTime)
 
       expectResult()
       expect(chalk.red).toHaveBeenCalledWith('  3 errors')
@@ -156,7 +156,7 @@ describe('colourLog', () => {
       colourLog.result({
         ...commonResult,
         warningCount: 1,
-      }, now)
+      }, startTime)
 
       expectResult()
       expect(chalk.yellow).toHaveBeenCalledWith('  1 warning')
@@ -167,7 +167,7 @@ describe('colourLog', () => {
       colourLog.result({
         ...commonResult,
         warningCount: 5,
-      }, now)
+      }, startTime)
 
       expectResult()
       expect(chalk.yellow).toHaveBeenCalledWith('  5 warnings')
@@ -179,7 +179,7 @@ describe('colourLog', () => {
         ...commonResult,
         warningCount: 6,
         fixableWarningCount: 3,
-      }, now)
+      }, startTime)
 
       expectResult()
       expect(chalk.yellow).toHaveBeenCalledWith('  6 warnings')
@@ -187,11 +187,23 @@ describe('colourLog', () => {
       expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '  6 warnings (3 fixable)')
     })
 
-    it('logs the deprecated rules which are being used', () => {
+    it('logs the deprecated rule count in magenta and the list in dim (single deprecation)', () => {
+      colourLog.result({
+        ...commonResult,
+        deprecatedRules: ['foo'],
+      }, startTime)
+
+      expectResult()
+      expect(chalk.magenta).toHaveBeenCalledWith('  1 deprecation')
+      expect(chalk.dim).toHaveBeenCalledWith(' [foo]')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '  1 deprecation [foo]')
+    })
+
+    it('logs the deprecated rule count in magenta and the list alphabetised in dim (multiple deprecations)', () => {
       colourLog.result({
         ...commonResult,
         deprecatedRules: ['foo', 'bar', 'baz'],
-      }, now)
+      }, startTime)
 
       expectResult()
       expect(chalk.magenta).toHaveBeenCalledWith('  3 deprecations')
@@ -207,7 +219,7 @@ describe('colourLog', () => {
         fixableErrorCount: 1,
         warningCount: 3,
         fixableWarningCount: 2,
-      }, now)
+      }, startTime)
 
       expectResult()
       expect(chalk.red).toHaveBeenCalledWith('  2 errors')
@@ -222,7 +234,7 @@ describe('colourLog', () => {
 
   describe('resultBlock', () => {
 
-    const commonResult = {
+    const commonResult: ProcessedResult = {
       deprecatedRules: [],
       errorCount: 0,
       fileCount: 1,
@@ -241,7 +253,7 @@ describe('colourLog', () => {
       expect(chalk.bgRed.black).toHaveBeenCalledTimes(1)
       expect(chalk.bgRed.black).toHaveBeenCalledWith(' 1 ESLint Error ')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('💔  1 ESLint Error \n')
+      expect(mockedConsoleLog).toHaveBeenCalledWith('🚨  1 ESLint Error \n')
     })
 
     it('logs the warning count in a yellow background', () => {
@@ -268,7 +280,7 @@ describe('colourLog', () => {
       expect(chalk.bgYellow.black).toHaveBeenCalledTimes(1)
       expect(chalk.bgYellow.black).toHaveBeenCalledWith(' 3 ESLint Warnings ')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('💔  2 ESLint Errors \n')
+      expect(mockedConsoleLog).toHaveBeenCalledWith('🚨  2 ESLint Errors \n')
       expect(mockedConsoleLog).toHaveBeenCalledWith('🚧  3 ESLint Warnings \n')
     })
 

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -54,6 +54,48 @@ describe('colourLog', () => {
 
   })
 
+  describe('error', () => {
+
+    it('logs the text in red', () => {
+      colourLog.error('An error occurred.')
+
+      expect(chalk.red).toHaveBeenCalledTimes(1)
+      expect(chalk.red).toHaveBeenCalledWith('An error occurred.')
+      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
+      expect(mockedConsoleLog).toHaveBeenCalledWith('An error occurred.')
+    })
+
+    it('logs the text in red but does not log the error if global.debug is false', () => {
+      const mockedConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+      global.debug = false
+
+      const error = new Error('Oops')
+      colourLog.error('An error occurred.', error)
+
+      expect(chalk.red).toHaveBeenCalledTimes(1)
+      expect(chalk.red).toHaveBeenCalledWith('An error occurred.')
+      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
+      expect(mockedConsoleLog).toHaveBeenCalledWith('An error occurred.')
+      expect(mockedConsoleError).toHaveBeenCalledTimes(0)
+    })
+
+    it('logs the text in red and logs the error if global.debug is true', () => {
+      const mockedConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+      global.debug = true
+
+      const error = new Error('Oops')
+      colourLog.error('An error occurred.', error)
+
+      expect(chalk.red).toHaveBeenCalledTimes(1)
+      expect(chalk.red).toHaveBeenCalledWith('An error occurred.')
+      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
+      expect(mockedConsoleLog).toHaveBeenCalledWith('An error occurred.')
+      expect(mockedConsoleError).toHaveBeenCalledTimes(1)
+      expect(mockedConsoleError).toHaveBeenCalledWith(error)
+    })
+
+  })
+
   describe('info', () => {
 
     it('logs the text in blue', () => {

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -57,12 +57,12 @@ describe('colourLog', () => {
   describe('error', () => {
 
     it('logs the text in red', () => {
-      colourLog.error('An error occurred.')
+      colourLog.error('An error occurred')
 
       expect(chalk.red).toHaveBeenCalledTimes(1)
-      expect(chalk.red).toHaveBeenCalledWith('An error occurred.')
+      expect(chalk.red).toHaveBeenCalledWith('An error occurred')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('An error occurred.')
+      expect(mockedConsoleLog).toHaveBeenCalledWith('An error occurred')
     })
 
     it('logs the text in red but does not log the error if global.debug is false', () => {
@@ -70,12 +70,12 @@ describe('colourLog', () => {
       global.debug = false
 
       const error = new Error('Oops')
-      colourLog.error('An error occurred.', error)
+      colourLog.error('An error occurred', error)
 
       expect(chalk.red).toHaveBeenCalledTimes(1)
-      expect(chalk.red).toHaveBeenCalledWith('An error occurred.')
+      expect(chalk.red).toHaveBeenCalledWith('An error occurred')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('An error occurred.')
+      expect(mockedConsoleLog).toHaveBeenCalledWith('An error occurred')
       expect(mockedConsoleError).toHaveBeenCalledTimes(0)
     })
 
@@ -84,12 +84,12 @@ describe('colourLog', () => {
       global.debug = true
 
       const error = new Error('Oops')
-      colourLog.error('An error occurred.', error)
+      colourLog.error('An error occurred', error)
 
       expect(chalk.red).toHaveBeenCalledTimes(1)
-      expect(chalk.red).toHaveBeenCalledWith('An error occurred.')
+      expect(chalk.red).toHaveBeenCalledWith('An error occurred')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('An error occurred.')
+      expect(mockedConsoleLog).toHaveBeenCalledWith('An error occurred')
       expect(mockedConsoleError).toHaveBeenCalledTimes(1)
       expect(mockedConsoleError).toHaveBeenCalledWith(error)
     })

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -65,7 +65,9 @@ describe('colourLog', () => {
       colourLog.configDebug('Debug message', 'config')
 
       expect(chalk.blue).toHaveBeenCalledOnceWith('Debug message')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n', 'Debug message', '\n', 'config')
+      expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nDebug message')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, 'config')
     })
 
   })
@@ -78,7 +80,7 @@ describe('colourLog', () => {
       colourLog.error('An error occurred')
 
       expect(chalk.red).toHaveBeenCalledOnceWith('An error occurred')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n', 'An error occurred')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\nAn error occurred')
     })
 
     it('logs the text in red but does not log the error if global.debug is false', () => {
@@ -88,7 +90,7 @@ describe('colourLog', () => {
 
       expect(chalk.red).toHaveBeenCalledOnceWith('An error occurred')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n', 'An error occurred')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nAn error occurred')
     })
 
     it('logs the text in red and logs the error if global.debug is true', () => {
@@ -98,7 +100,7 @@ describe('colourLog', () => {
 
       expect(chalk.red).toHaveBeenCalledOnceWith('An error occurred')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n', 'An error occurred')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nAn error occurred')
       expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, error)
     })
 
@@ -134,7 +136,7 @@ describe('colourLog', () => {
       expect(chalk.cyan).toHaveBeenCalledWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledWith('[1 file, 1000ms]')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n', 'Finished eslint', '[1 file, 1000ms]')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nFinished eslint', '[1 file, 1000ms]')
     }
 
     it('logs the finished lint message along with the file count and duration (single file)', () => {
@@ -142,7 +144,7 @@ describe('colourLog', () => {
 
       expect(chalk.cyan).toHaveBeenCalledOnceWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledOnceWith('[1 file, 1000ms]')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n', 'Finished eslint', '[1 file, 1000ms]')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\nFinished eslint', '[1 file, 1000ms]')
     })
 
     it('logs the finished lint message along with the file count and duration (multiple files)', () => {
@@ -153,7 +155,7 @@ describe('colourLog', () => {
 
       expect(chalk.cyan).toHaveBeenCalledOnceWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledOnceWith('[7 files, 1000ms]')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n', 'Finished eslint', '[7 files, 1000ms]')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\nFinished eslint', '[7 files, 1000ms]')
     })
 
     it('logs the error count in red (single error)', () => {

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -271,6 +271,7 @@ describe('colourLog', () => {
       expect(chalk.dim).toHaveBeenCalledWith(' [bar, baz, foo]')
       expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  2 errors (1 fixable)\n  3 warnings (2 fixable)\n  3 deprecations [bar, baz, foo]')
     })
+
   })
 
   describe('resultBlock', () => {

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -33,65 +33,73 @@ describe('colourLog', () => {
     it('logs the key in magenta and a single config item in dim', () => {
       colourLog.config('setting', ['foo'])
 
-      expect(chalk.magenta).toHaveBeenCalledTimes(1)
-      expect(chalk.magenta).toHaveBeenCalledWith('setting: ')
-      expect(chalk.dim).toHaveBeenCalledTimes(1)
-      expect(chalk.dim).toHaveBeenCalledWith('foo')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('setting: ', 'foo')
+      expect(chalk.magenta).toHaveBeenCalledOnceWith('setting: ')
+      expect(chalk.dim).toHaveBeenCalledOnceWith('foo')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('setting: ', 'foo')
     })
 
     it('logs the key in magenta and the config array in dim', () => {
       colourLog.config('setting', ['foo', 'bar', 'baz'])
 
-      expect(chalk.magenta).toHaveBeenCalledTimes(1)
-      expect(chalk.magenta).toHaveBeenCalledWith('setting: ')
-      expect(chalk.dim).toHaveBeenCalledTimes(1)
-      expect(chalk.dim).toHaveBeenCalledWith('[foo, bar, baz]')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('setting: ', '[foo, bar, baz]')
+      expect(chalk.magenta).toHaveBeenCalledOnceWith('setting: ')
+      expect(chalk.dim).toHaveBeenCalledOnceWith('[foo, bar, baz]')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('setting: ', '[foo, bar, baz]')
+    })
+
+  })
+
+  describe('configDebug', () => {
+
+    it('does not log if global.debug is false', () => {
+      global.debug = false
+
+      colourLog.configDebug('Debug message', 'config')
+
+      expect(chalk.blue).not.toHaveBeenCalled()
+      expect(mockedConsoleLog).not.toHaveBeenCalled()
+    })
+
+    it('logs the message in blue and the config in default if global.debug is true', () => {
+      global.debug = true
+
+      colourLog.configDebug('Debug message', 'config')
+
+      expect(chalk.blue).toHaveBeenCalledOnceWith('Debug message')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n', 'Debug message', '\n', 'config')
     })
 
   })
 
   describe('error', () => {
 
+    const error = new Error('Oops')
+
     it('logs the text in red', () => {
       colourLog.error('An error occurred')
 
-      expect(chalk.red).toHaveBeenCalledTimes(1)
-      expect(chalk.red).toHaveBeenCalledWith('An error occurred')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('An error occurred')
+      expect(chalk.red).toHaveBeenCalledOnceWith('An error occurred')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n', 'An error occurred')
     })
 
     it('logs the text in red but does not log the error if global.debug is false', () => {
-      const mockedConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
       global.debug = false
 
-      const error = new Error('Oops')
       colourLog.error('An error occurred', error)
 
-      expect(chalk.red).toHaveBeenCalledTimes(1)
-      expect(chalk.red).toHaveBeenCalledWith('An error occurred')
+      expect(chalk.red).toHaveBeenCalledOnceWith('An error occurred')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('An error occurred')
-      expect(mockedConsoleError).toHaveBeenCalledTimes(0)
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n', 'An error occurred')
     })
 
     it('logs the text in red and logs the error if global.debug is true', () => {
-      const mockedConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
       global.debug = true
 
-      const error = new Error('Oops')
       colourLog.error('An error occurred', error)
 
-      expect(chalk.red).toHaveBeenCalledTimes(1)
-      expect(chalk.red).toHaveBeenCalledWith('An error occurred')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('An error occurred')
-      expect(mockedConsoleError).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleError).toHaveBeenCalledWith(error)
+      expect(chalk.red).toHaveBeenCalledOnceWith('An error occurred')
+      expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n', 'An error occurred')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, error)
     })
 
   })
@@ -101,10 +109,8 @@ describe('colourLog', () => {
     it('logs the text in blue', () => {
       colourLog.info('Starting lint...')
 
-      expect(chalk.blue).toHaveBeenCalledTimes(1)
-      expect(chalk.blue).toHaveBeenCalledWith('Starting lint...')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('Starting lint...')
+      expect(chalk.blue).toHaveBeenCalledOnceWith('Starting lint...')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('Starting lint...')
     })
 
   })
@@ -126,22 +132,18 @@ describe('colourLog', () => {
 
     const expectResult = () => {
       expect(chalk.cyan).toHaveBeenCalledWith('Finished eslint')
-      expect(chalk.yellow).toHaveBeenCalledWith(`[1 file, 1000ms]`)
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(3)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, 'Finished eslint', `[1 file, 1000ms]`)
+      expect(chalk.yellow).toHaveBeenCalledWith('[1 file, 1000ms]')
+      expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n', 'Finished eslint', `[1 file, 1000ms]`)
     }
 
     it('logs the finished lint message along with the file count and duration (single file)', () => {
       colourLog.result(commonResult, startTime)
 
-      expect(chalk.cyan).toHaveBeenCalledTimes(1)
-      expect(chalk.cyan).toHaveBeenCalledWith('Finished eslint')
-      expect(chalk.yellow).toHaveBeenCalledTimes(1)
-      expect(chalk.yellow).toHaveBeenCalledWith('[1 file, 1000ms]')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, 'Finished eslint', '[1 file, 1000ms]')
+      expect(chalk.cyan).toHaveBeenCalledOnceWith('Finished eslint')
+      expect(chalk.yellow).toHaveBeenCalledOnceWith('[1 file, 1000ms]')
+      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n', 'Finished eslint', '[1 file, 1000ms]')
     })
 
     it('logs the finished lint message along with the file count and duration (multiple files)', () => {
@@ -150,13 +152,10 @@ describe('colourLog', () => {
         fileCount: 7,
       }, startTime)
 
-      expect(chalk.cyan).toHaveBeenCalledTimes(1)
-      expect(chalk.cyan).toHaveBeenCalledWith('Finished eslint')
-      expect(chalk.yellow).toHaveBeenCalledTimes(1)
-      expect(chalk.yellow).toHaveBeenCalledWith('[7 files, 1000ms]')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, 'Finished eslint', '[7 files, 1000ms]')
+      expect(chalk.cyan).toHaveBeenCalledOnceWith('Finished eslint')
+      expect(chalk.yellow).toHaveBeenCalledOnceWith('[7 files, 1000ms]')
+      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n', 'Finished eslint', '[7 files, 1000ms]')
     })
 
     it('logs the error count in red (single error)', () => {
@@ -167,7 +166,7 @@ describe('colourLog', () => {
 
       expectResult()
       expect(chalk.red).toHaveBeenCalledWith('  1 error')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '  1 error')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  1 error')
     })
 
     it('logs the error count in red (multiple errors)', () => {
@@ -178,7 +177,7 @@ describe('colourLog', () => {
 
       expectResult()
       expect(chalk.red).toHaveBeenCalledWith('  2 errors')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '  2 errors')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  2 errors')
     })
 
     it('logs the error count in red with the fixable error count in dim', () => {
@@ -191,7 +190,7 @@ describe('colourLog', () => {
       expectResult()
       expect(chalk.red).toHaveBeenCalledWith('  3 errors')
       expect(chalk.dim).toHaveBeenCalledWith(' (2 fixable)')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '  3 errors (2 fixable)')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  3 errors (2 fixable)')
     })
 
     it('logs the warning count in yellow (single warning)', () => {
@@ -202,7 +201,7 @@ describe('colourLog', () => {
 
       expectResult()
       expect(chalk.yellow).toHaveBeenCalledWith('  1 warning')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '  1 warning')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  1 warning')
     })
 
     it('logs the warning count in yellow (multiple warnings)', () => {
@@ -213,7 +212,7 @@ describe('colourLog', () => {
 
       expectResult()
       expect(chalk.yellow).toHaveBeenCalledWith('  5 warnings')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '  5 warnings')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  5 warnings')
     })
 
     it('logs the warning count in yellow with the fixable warning count in dim', () => {
@@ -226,7 +225,7 @@ describe('colourLog', () => {
       expectResult()
       expect(chalk.yellow).toHaveBeenCalledWith('  6 warnings')
       expect(chalk.dim).toHaveBeenCalledWith(' (3 fixable)')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '  6 warnings (3 fixable)')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  6 warnings (3 fixable)')
     })
 
     it('logs the deprecated rule count in magenta and the list in dim (single deprecation)', () => {
@@ -238,7 +237,7 @@ describe('colourLog', () => {
       expectResult()
       expect(chalk.magenta).toHaveBeenCalledWith('  1 deprecation')
       expect(chalk.dim).toHaveBeenCalledWith(' [foo]')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '  1 deprecation [foo]')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  1 deprecation [foo]')
     })
 
     it('logs the deprecated rule count in magenta and the list alphabetised in dim (multiple deprecations)', () => {
@@ -250,7 +249,7 @@ describe('colourLog', () => {
       expectResult()
       expect(chalk.magenta).toHaveBeenCalledWith('  3 deprecations')
       expect(chalk.dim).toHaveBeenCalledWith(' [bar, baz, foo]')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '  3 deprecations [bar, baz, foo]')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  3 deprecations [bar, baz, foo]')
     })
 
     it('logs everything together', () => {
@@ -270,7 +269,7 @@ describe('colourLog', () => {
       expect(chalk.dim).toHaveBeenCalledWith(' (2 fixable)')
       expect(chalk.magenta).toHaveBeenCalledWith('  3 deprecations')
       expect(chalk.dim).toHaveBeenCalledWith(' [bar, baz, foo]')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '  2 errors (1 fixable)\n  3 warnings (2 fixable)\n  3 deprecations [bar, baz, foo]')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  2 errors (1 fixable)\n  3 warnings (2 fixable)\n  3 deprecations [bar, baz, foo]')
     })
   })
 
@@ -292,10 +291,8 @@ describe('colourLog', () => {
         errorCount: 1,
       })
 
-      expect(chalk.bgRed.black).toHaveBeenCalledTimes(1)
-      expect(chalk.bgRed.black).toHaveBeenCalledWith(' 1 ESLint Error ')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('🚨  1 ESLint Error \n')
+      expect(chalk.bgRed.black).toHaveBeenCalledOnceWith(' 1 ESLint Error ')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n🚨  1 ESLint Error ')
     })
 
     it('logs the warning count in a yellow background', () => {
@@ -304,10 +301,8 @@ describe('colourLog', () => {
         warningCount: 1,
       })
 
-      expect(chalk.bgYellow.black).toHaveBeenCalledTimes(1)
-      expect(chalk.bgYellow.black).toHaveBeenCalledWith(' 1 ESLint Warning ')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('🚧  1 ESLint Warning \n')
+      expect(chalk.bgYellow.black).toHaveBeenCalledOnceWith(' 1 ESLint Warning ')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n🚧  1 ESLint Warning ')
     })
 
     it('logs the both the error and warning counts if both are present', () => {
@@ -317,22 +312,18 @@ describe('colourLog', () => {
         warningCount: 3,
       })
 
-      expect(chalk.bgRed.black).toHaveBeenCalledTimes(1)
-      expect(chalk.bgRed.black).toHaveBeenCalledWith(' 2 ESLint Errors ')
-      expect(chalk.bgYellow.black).toHaveBeenCalledTimes(1)
-      expect(chalk.bgYellow.black).toHaveBeenCalledWith(' 3 ESLint Warnings ')
+      expect(chalk.bgRed.black).toHaveBeenCalledOnceWith(' 2 ESLint Errors ')
+      expect(chalk.bgYellow.black).toHaveBeenCalledOnceWith(' 3 ESLint Warnings ')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('🚨  2 ESLint Errors \n')
-      expect(mockedConsoleLog).toHaveBeenCalledWith('🚧  3 ESLint Warnings \n')
+      expect(mockedConsoleLog).toHaveBeenCalledWith('\n🚨  2 ESLint Errors ')
+      expect(mockedConsoleLog).toHaveBeenCalledWith('\n🚧  3 ESLint Warnings ')
     })
 
     it('logs a success message if there are no errors or warnings', () => {
       colourLog.resultBlock(commonResult)
 
-      expect(chalk.bgGreen.black).toHaveBeenCalledTimes(1)
-      expect(chalk.bgGreen.black).toHaveBeenCalledWith(' ESLint Success! ')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('✅  ESLint Success! \n')
+      expect(chalk.bgGreen.black).toHaveBeenCalledOnceWith(' ESLint Success! ')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n✅  ESLint Success! ')
     })
 
   })
@@ -342,10 +333,8 @@ describe('colourLog', () => {
     it('logs the title in cyan', () => {
       colourLog.title('✈️ Lint Pilot ✈️')
 
-      expect(chalk.cyan).toHaveBeenCalledTimes(1)
-      expect(chalk.cyan).toHaveBeenCalledWith('✈️ Lint Pilot ✈️')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('✈️ Lint Pilot ✈️')
+      expect(chalk.cyan).toHaveBeenCalledOnceWith('✈️ Lint Pilot ✈️')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('✈️ Lint Pilot ✈️')
     })
 
   })

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -142,7 +142,7 @@ describe('colourLog', () => {
 
       expect(chalk.cyan).toHaveBeenCalledOnceWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledOnceWith('[1 file, 1000ms]')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith(1, '\n', 'Finished eslint', '[1 file, 1000ms]')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n', 'Finished eslint', '[1 file, 1000ms]')
     })
 
     it('logs the finished lint message along with the file count and duration (multiple files)', () => {
@@ -153,7 +153,7 @@ describe('colourLog', () => {
 
       expect(chalk.cyan).toHaveBeenCalledOnceWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledOnceWith('[7 files, 1000ms]')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith(1, '\n', 'Finished eslint', '[7 files, 1000ms]')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n', 'Finished eslint', '[7 files, 1000ms]')
     })
 
     it('logs the error count in red (single error)', () => {

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -134,7 +134,7 @@ describe('colourLog', () => {
       expect(chalk.cyan).toHaveBeenCalledWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledWith('[1 file, 1000ms]')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n', 'Finished eslint', `[1 file, 1000ms]`)
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n', 'Finished eslint', '[1 file, 1000ms]')
     }
 
     it('logs the finished lint message along with the file count and duration (single file)', () => {
@@ -142,8 +142,7 @@ describe('colourLog', () => {
 
       expect(chalk.cyan).toHaveBeenCalledOnceWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledOnceWith('[1 file, 1000ms]')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n', 'Finished eslint', '[1 file, 1000ms]')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith(1, '\n', 'Finished eslint', '[1 file, 1000ms]')
     })
 
     it('logs the finished lint message along with the file count and duration (multiple files)', () => {
@@ -154,8 +153,7 @@ describe('colourLog', () => {
 
       expect(chalk.cyan).toHaveBeenCalledOnceWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledOnceWith('[7 files, 1000ms]')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n', 'Finished eslint', '[7 files, 1000ms]')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith(1, '\n', 'Finished eslint', '[7 files, 1000ms]')
     })
 
     it('logs the error count in red (single error)', () => {
@@ -316,8 +314,8 @@ describe('colourLog', () => {
       expect(chalk.bgRed.black).toHaveBeenCalledOnceWith(' 2 ESLint Errors ')
       expect(chalk.bgYellow.black).toHaveBeenCalledOnceWith(' 3 ESLint Warnings ')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleLog).toHaveBeenCalledWith('\n🚨  2 ESLint Errors ')
-      expect(mockedConsoleLog).toHaveBeenCalledWith('\n🚧  3 ESLint Warnings ')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n🚨  2 ESLint Errors ')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '\n🚧  3 ESLint Warnings ')
     })
 
     it('logs a success message if there are no errors or warnings', () => {

--- a/src/utils/__tests__/notifier.spec.ts
+++ b/src/utils/__tests__/notifier.spec.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals'
 import notifier from 'node-notifier'
 
-import { Linter } from '@Types'
+import { Linter, type LinterResult } from '@Types'
 
 import { notifyResults } from '../notifier'
 
@@ -13,7 +13,7 @@ describe('notifier', () => {
 
   describe('notifyResults', () => {
 
-    const generateResult = (errorCount = 0, warningCount = 0) => ({
+    const generateResult = (errorCount = 0, warningCount = 0): LinterResult => ({
       processedResult: {
         deprecatedRules: [],
         errorCount,

--- a/src/utils/__tests__/notifier.spec.ts
+++ b/src/utils/__tests__/notifier.spec.ts
@@ -9,125 +9,116 @@ jest.mock('node-notifier', () => ({
   notify: jest.fn(),
 }))
 
-describe('notifier', () => {
+describe('notifyResults', () => {
 
-  describe('notifyResults', () => {
+  const generateResult = (errorCount = 0, warningCount = 0): LinterResult => ({
+    processedResult: {
+      deprecatedRules: [],
+      errorCount,
+      fileCount: 0,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0,
+      linter: Linter.ESLint,
+      warningCount,
+    },
+  })
 
-    const generateResult = (errorCount = 0, warningCount = 0): LinterResult => ({
-      processedResult: {
-        deprecatedRules: [],
-        errorCount,
-        fileCount: 0,
-        fixableErrorCount: 0,
-        fixableWarningCount: 0,
-        linter: Linter.ESLint,
-        warningCount,
-      },
+  it('returns an exit code of 1 if there are errors', () => {
+    const exitCode = notifyResults([
+      generateResult(0, 0),
+      generateResult(1, 0),
+      generateResult(0, 1),
+    ], 'Lint Pilot')
+
+    expect(exitCode).toBe(1)
+  })
+
+  it('returns an exit code of 0 if there are no errors, but there are warnings', () => {
+    const exitCode = notifyResults([
+      generateResult(0, 0),
+      generateResult(0, 0),
+      generateResult(0, 1),
+    ], 'Lint Pilot')
+
+    expect(exitCode).toBe(0)
+  })
+
+  it('returns an exit code of 0 if there are no errors or warnings', () => {
+    const exitCode = notifyResults([
+      generateResult(0, 0),
+      generateResult(0, 0),
+    ], 'Lint Pilot')
+
+    expect(exitCode).toBe(0)
+  })
+
+  it('notifies when there is a single error', () => {
+    notifyResults([
+      generateResult(0, 0),
+      generateResult(1, 1),
+      generateResult(0, 1),
+    ], 'Lint Pilot')
+
+    expect(notifier.notify).toHaveBeenCalledOnceWith({
+      message: '1 error found. Please fix it before continuing.',
+      sound: 'Frog',
+      title: '🚨 Lint Pilot 🚨',
     })
+  })
 
-    it('returns an exit code of 1 if there are errors', () => {
-      const exitCode = notifyResults([
-        generateResult(0, 0),
-        generateResult(1, 0),
-        generateResult(0, 1),
-      ], 'Lint Pilot')
+  it('notifies when there are multiple errors', () => {
+    notifyResults([
+      generateResult(0, 0),
+      generateResult(5, 0),
+      generateResult(2, 1),
+    ], 'Lint Pilot')
 
-      expect(exitCode).toBe(1)
+    expect(notifier.notify).toHaveBeenCalledOnceWith({
+      message: '7 errors found. Please fix them before continuing.',
+      sound: 'Frog',
+      title: '🚨 Lint Pilot 🚨',
     })
+  })
 
-    it('returns an exit code of 0 if there are no errors, but there are warnings', () => {
-      const exitCode = notifyResults([
-        generateResult(0, 0),
-        generateResult(0, 0),
-        generateResult(0, 1),
-      ], 'Lint Pilot')
+  it('notifies when there is a single warning', () => {
+    notifyResults([
+      generateResult(0, 0),
+      generateResult(0, 0),
+      generateResult(0, 1),
+    ], 'Lint Pilot')
 
-      expect(exitCode).toBe(0)
+    expect(notifier.notify).toHaveBeenCalledOnceWith({
+      message: '1 warning found. Please review before continuing.',
+      sound: 'Frog',
+      title: '🚧 Lint Pilot 🚧',
     })
+  })
 
-    it('returns an exit code of 0 if there are no errors or warnings', () => {
-      const exitCode = notifyResults([
-        generateResult(0, 0),
-        generateResult(0, 0),
-      ], 'Lint Pilot')
+  it('notifies when there are multiple warnings', () => {
+    notifyResults([
+      generateResult(0, 0),
+      generateResult(0, 7),
+      generateResult(0, 2),
+    ], 'Lint Pilot')
 
-      expect(exitCode).toBe(0)
+    expect(notifier.notify).toHaveBeenCalledOnceWith({
+      message: '9 warnings found. Please review them before continuing.',
+      sound: 'Frog',
+      title: '🚧 Lint Pilot 🚧',
     })
+  })
 
-    it('notifies the user when there is a single error', () => {
-      notifyResults([
-        generateResult(0, 0),
-        generateResult(1, 1),
-        generateResult(0, 1),
-      ], 'Lint Pilot')
+  it('notifies when there are no errors or warnings', () => {
+    notifyResults([
+      generateResult(0, 0),
+      generateResult(0, 0),
+    ], 'Lint Pilot')
 
-      expect(notifier.notify).toHaveBeenCalledTimes(1)
-      expect(notifier.notify).toHaveBeenCalledWith({
-        message: `1 error found. Please fix it before continuing.`,
-        sound: 'Frog',
-        title: '🚨 Lint Pilot 🚨',
-      })
+    expect(notifier.notify).toHaveBeenCalledOnceWith({
+      message: 'All lint checks have passed. Your code is clean!',
+      sound: 'Purr',
+      title: '✅ Lint Pilot ✅',
     })
-
-    it('notifies the user when there is are multiple errors', () => {
-      notifyResults([
-        generateResult(0, 0),
-        generateResult(5, 0),
-        generateResult(2, 1),
-      ], 'Lint Pilot')
-
-      expect(notifier.notify).toHaveBeenCalledTimes(1)
-      expect(notifier.notify).toHaveBeenCalledWith({
-        message: `7 errors found. Please fix them before continuing.`,
-        sound: 'Frog',
-        title: '🚨 Lint Pilot 🚨',
-      })
-    })
-
-    it('notifies the user when there is a single warning', () => {
-      notifyResults([
-        generateResult(0, 0),
-        generateResult(0, 0),
-        generateResult(0, 1),
-      ], 'Lint Pilot')
-
-      expect(notifier.notify).toHaveBeenCalledTimes(1)
-      expect(notifier.notify).toHaveBeenCalledWith({
-        message: `1 warning found. Please review before continuing.`,
-        sound: 'Frog',
-        title: '🚧 Lint Pilot 🚧',
-      })
-    })
-
-    it('notifies the user when there is are multiple warnings', () => {
-      notifyResults([
-        generateResult(0, 0),
-        generateResult(0, 7),
-        generateResult(0, 2),
-      ], 'Lint Pilot')
-
-      expect(notifier.notify).toHaveBeenCalledTimes(1)
-      expect(notifier.notify).toHaveBeenCalledWith({
-        message: `9 warnings found. Please review them before continuing.`,
-        sound: 'Frog',
-        title: '🚧 Lint Pilot 🚧',
-      })
-    })
-
-    it('notifies the user when there are no errors or warnings', () => {
-      notifyResults([
-        generateResult(0, 0),
-        generateResult(0, 0),
-      ], 'Lint Pilot')
-
-      expect(notifier.notify).toHaveBeenCalledTimes(1)
-      expect(notifier.notify).toHaveBeenCalledWith({
-        message: 'All lint checks have passed. Your code is clean!',
-        sound: 'Purr',
-        title: '✅ Lint Pilot ✅',
-      })
-    })
-
   })
 
 })

--- a/src/utils/__tests__/terminal.spec.ts
+++ b/src/utils/__tests__/terminal.spec.ts
@@ -8,7 +8,6 @@ describe('clearTerminal', () => {
     clearTerminal()
 
     expect(mockWrite).toHaveBeenCalledWith('\x1Bc\x1B[3J\x1B[2J\x1B[H')
-    mockWrite.mockRestore()
   })
 
 })

--- a/src/utils/__tests__/transform.spec.ts
+++ b/src/utils/__tests__/transform.spec.ts
@@ -1,18 +1,14 @@
 import { pluralise } from '../transform'
 
-describe('transform', () => {
+describe('pluralise', () => {
 
-  describe('pluralise', () => {
+  it('returns the original word if count is 1', () => {
+    expect(pluralise('apple', 1)).toBe('apple')
+  })
 
-    it('returns the original word if count is 1', () => {
-      expect(pluralise('apple', 1)).toBe('apple')
-    })
-
-    it('returns the pluralised word if count is not 1', () => {
-      expect(pluralise('apple', 0)).toBe('apples')
-      expect(pluralise('apple', 2)).toBe('apples')
-    })
-
+  it('returns the pluralised word if count is not 1', () => {
+    expect(pluralise('apple', 0)).toBe('apples')
+    expect(pluralise('apple', 2)).toBe('apples')
   })
 
 })

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -6,17 +6,23 @@ import type { ProcessedResult } from '@Types'
 
 const colourLog = {
   config: (key: string, configArray: Array<string>) => {
-    const configString = configArray.length >= 2
+    const configString = configArray.length > 1
       ? `[${configArray.join(', ')}]`
       : configArray[0]
 
     console.log(chalk.magenta(`${key}: `), chalk.dim(configString))
   },
 
+  configDebug: (message: string, config: string) => {
+    if (global.debug) {
+      console.log('\n', chalk.blue(message), '\n', config)
+    }
+  },
+
   error: (text: string, error?: Error | unknown) => {
-    console.log(chalk.red(text))
+    console.log('\n', chalk.red(text))
     if (error && global.debug === true) {
-      console.error(error)
+      console.log(error)
     }
   },
 
@@ -57,8 +63,7 @@ const colourLog = {
     const files = `${fileCount} ${pluralise('file', fileCount)}`
     const endTime = `${new Date().getTime() - startTime}ms`
 
-    console.log()
-    console.log(chalk.cyan(`Finished ${linter.toLowerCase()}`), chalk.yellow(`[${files}, ${endTime}]`))
+    console.log('\n', chalk.cyan(`Finished ${linter.toLowerCase()}`), chalk.yellow(`[${files}, ${endTime}]`))
     if (log.length) {
       console.log(log.join('\n'))
     }
@@ -68,19 +73,19 @@ const colourLog = {
     // Errors
     if (errorCount > 0) {
       const message = chalk.bgRed.black(` ${errorCount} ${linter} ${pluralise('Error', errorCount)} `)
-      console.log(`🚨 ${message}\n`)
+      console.log(`\n🚨 ${message}`)
     }
 
     // Warnings
     if (warningCount > 0) {
       const message = chalk.bgYellow.black(` ${warningCount} ${linter} ${pluralise('Warning', warningCount)} `)
-      console.log(`🚧 ${message}\n`)
+      console.log(`\n🚧 ${message}`)
     }
 
     // Success
     if (errorCount === 0 && warningCount === 0) {
       const message = chalk.bgGreen.black(` ${linter} Success! `)
-      console.log(`✅ ${message}\n`)
+      console.log(`\n✅ ${message}`)
     }
   },
 

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -13,7 +13,7 @@ const colourLog = {
     console.log(chalk.magenta(`${key}: `), chalk.dim(configString))
   },
 
-  configDebug: (message: string, config: string) => {
+  configDebug: (message: string, config: string | Array<string>) => {
     if (global.debug) {
       console.log('\n', chalk.blue(message), '\n', config)
     }

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -15,12 +15,13 @@ const colourLog = {
 
   configDebug: (message: string, config: any) => {
     if (global.debug) {
-      console.log('\n', chalk.blue(message), '\n', config)
+      console.log(`\n${chalk.blue(message)}`)
+      console.log(config)
     }
   },
 
   error: (text: string, error?: Error | unknown) => {
-    console.log('\n', chalk.red(text))
+    console.log(`\n${chalk.red(text)}`)
     if (error && global.debug === true) {
       console.log(error)
     }
@@ -60,10 +61,11 @@ const colourLog = {
     }
 
     // Output
+    const finishedLinter = chalk.cyan(`Finished ${linter.toLowerCase()}`)
     const files = `${fileCount} ${pluralise('file', fileCount)}`
     const endTime = `${new Date().getTime() - startTime}ms`
 
-    console.log('\n', chalk.cyan(`Finished ${linter.toLowerCase()}`), chalk.yellow(`[${files}, ${endTime}]`))
+    console.log(`\n${finishedLinter}`, chalk.yellow(`[${files}, ${endTime}]`))
     if (log.length) {
       console.log(log.join('\n'))
     }

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -1,12 +1,16 @@
 import chalk from 'chalk'
 
-import { type ProcessedResult } from '@Types'
 import { pluralise } from '@Utils/transform'
+
+import type { ProcessedResult } from '@Types'
 
 const colourLog = {
   config: (key: string, configArray: Array<string>) => {
-    const configString = configArray.length >= 2 ? `[${configArray.join(', ')}]` : configArray[0]
-    console.log(chalk.magenta(`${key}:`), chalk.dim(configString))
+    const configString = configArray.length >= 2
+      ? `[${configArray.join(', ')}]`
+      : configArray[0]
+
+    console.log(chalk.magenta(`${key}: `), chalk.dim(configString))
   },
 
   info: (text: string) => console.log(chalk.blue(text)),
@@ -45,26 +49,32 @@ const colourLog = {
     // Output
     const files = `${fileCount} ${pluralise('file', fileCount)}`
     const endTime = `${new Date().getTime() - startTime}ms`
+
     console.log()
     console.log(chalk.cyan(`Finished ${linter.toLowerCase()}`), chalk.yellow(`[${files}, ${endTime}]`))
-    log.length && console.log(log.join('\n'))
+    if (log.length) {
+      console.log(log.join('\n'))
+    }
   },
 
   resultBlock: ({ errorCount, linter, warningCount }: ProcessedResult) => {
+    // Errors
     if (errorCount > 0) {
       const message = chalk.bgRed.black(` ${errorCount} ${linter} ${pluralise('Error', errorCount)} `)
-      console.log(`💔 ${message}\n`)
+      console.log(`🚨 ${message}\n`)
     }
+
+    // Warnings
     if (warningCount > 0) {
       const message = chalk.bgYellow.black(` ${warningCount} ${linter} ${pluralise('Warning', warningCount)} `)
       console.log(`🚧 ${message}\n`)
     }
-    if (errorCount > 0 || warningCount > 0) {
-      return
-    }
 
-    const message = chalk.bgGreen.black(` ${linter} Success! `)
-    console.log(`✅ ${message}\n`)
+    // Success
+    if (errorCount === 0 && warningCount === 0) {
+      const message = chalk.bgGreen.black(` ${linter} Success! `)
+      console.log(`✅ ${message}\n`)
+    }
   },
 
   title: (title: string) => console.log(chalk.cyan(title)),

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -13,7 +13,7 @@ const colourLog = {
     console.log(chalk.magenta(`${key}: `), chalk.dim(configString))
   },
 
-  configDebug: (message: string, config: string | Array<string>) => {
+  configDebug: (message: string, config: any) => {
     if (global.debug) {
       console.log('\n', chalk.blue(message), '\n', config)
     }

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -13,7 +13,7 @@ const colourLog = {
     console.log(chalk.magenta(`${key}: `), chalk.dim(configString))
   },
 
-  error: (text: string, error?: Error) => {
+  error: (text: string, error?: Error | unknown) => {
     console.log(chalk.red(text))
     if (error && global.debug === true) {
       console.error(error)

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -13,6 +13,13 @@ const colourLog = {
     console.log(chalk.magenta(`${key}: `), chalk.dim(configString))
   },
 
+  error: (text: string, error?: Error) => {
+    console.log(chalk.red(text))
+    if (error && global.debug === true) {
+      console.error(error)
+    }
+  },
+
   info: (text: string) => console.log(chalk.blue(text)),
 
   result: (processedResult: ProcessedResult, startTime: number) => {

--- a/src/utils/notifier.ts
+++ b/src/utils/notifier.ts
@@ -1,9 +1,11 @@
 import notifier from 'node-notifier'
 
-import { type LinterResult } from '@Types'
 import { pluralise } from '@Utils/transform'
 
+import type { LinterResult } from '@Types'
+
 const notifyResults = (results: Array<LinterResult>, title: string) => {
+  // Errors
   let totalErrorCount = results.reduce((total, { processedResult: { errorCount } }) => total + errorCount, 0)
   if (totalErrorCount > 0) {
     notifier.notify({
@@ -14,6 +16,7 @@ const notifyResults = (results: Array<LinterResult>, title: string) => {
     return 1
   }
 
+  // Warnings
   let totalWarningCount = results.reduce((total, { processedResult: { warningCount } }) => total + warningCount, 0)
   if (totalWarningCount > 0) {
     notifier.notify({
@@ -24,6 +27,7 @@ const notifyResults = (results: Array<LinterResult>, title: string) => {
     return 0
   }
 
+  // Success
   notifier.notify({
     message: 'All lint checks have passed. Your code is clean!',
     sound: 'Purr',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
   },
   "include": [
     "config/**/*.ts",
+    "jest-config/types.d.ts",
     "src/**/*.ts",
     "src/types/global.d.ts"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1481,6 +1481,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
+"@jridgewell/sourcemap-codec@^1.4.15":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
+  integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
+
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
@@ -1523,6 +1528,14 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@rollup/plugin-replace@5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-5.0.7.tgz#150c9ee9db8031d9e4580a61a0edeaaed3d37687"
+  integrity sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    magic-string "^0.30.3"
+
 "@rollup/plugin-typescript@11.1.6":
   version "11.1.6"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz#724237d5ec12609ec01429f619d2a3e7d4d1b22b"
@@ -1531,7 +1544,7 @@
     "@rollup/pluginutils" "^5.1.0"
     resolve "^1.22.1"
 
-"@rollup/pluginutils@^5.1.0":
+"@rollup/pluginutils@^5.0.1", "@rollup/pluginutils@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.1.0.tgz#7e53eddc8c7f483a4ad0b94afb1f7f5fd3c771e0"
   integrity sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==
@@ -3495,6 +3508,13 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+magic-string@^0.30.3:
+  version "0.30.10"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.10.tgz#123d9c41a0cb5640c892b041d4cfb3bd0aa4b39e"
+  integrity sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
 
 make-dir@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,7 +987,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/template@^7.24.6", "@babel/template@^7.24.7", "@babel/template@^7.3.3":
+"@babel/template@^7.24.6", "@babel/template@^7.24.7", "@babel/template@^7.3.3", "@babel/template@^7.4.4":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.24.7.tgz#02efcee317d0609d2c07117cb70ef8fb17ab7315"
   integrity sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==
@@ -1956,6 +1956,14 @@ babel-plugin-polyfill-regenerator@^0.6.1:
   integrity sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.6.2"
+
+babel-plugin-transform-import-meta@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-import-meta/-/babel-plugin-transform-import-meta-2.2.1.tgz#eb5b79019ff0a9157b94d8280955121189a2964b"
+  integrity sha512-AxNh27Pcg8Kt112RGa3Vod2QS2YXKKJ6+nSvRtv7qQTJAdx0MZa4UHZ4lnxHUWA2MNbLuZQv5FVab4P1CoLOWw==
+  dependencies:
+    "@babel/template" "^7.4.4"
+    tslib "^2.4.0"
 
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
@@ -4384,7 +4392,7 @@ ts-node@10.9.2:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@2.6.3:
+tslib@2.6.3, tslib@^2.4.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==


### PR DESCRIPTION
## Details

### What have you changed?

- 📑 Configured `markdownlint` to load custom config, defaulting to config defined by Lint Pilot.
- 🗞️ Installed and configured `@rollup/plugin-replace`.
- 🃏 Added a custom Jest matcher, `toHaveBeenCalledOnceWith`.
- 🌟 Improved unit tests, TypeScript types, utility functions, and global options such as `debug`.

### Why are you making these changes?

- 🗞️ The `@rollup/plugin-replace` plugin means we can have conditional logic, such as `if (process.env.NODE_ENV === 'development') { ... }`, which can be removed from the bundle when compiling the module.
- 🃏 In many tests we assert that a mock is called once and with the correct arguments. A primary use-case is when asserting `console.log` to ensure there are no unexpected logs. This custom matcher combines two assertions into one which helps keep the tests cleaner, leaner, and therefore easier to read and maintain.
- 🌟 Improvements:
  - The unit tests are more concise, clearer, and more maintainable.
  - The TypeScript types are defined clearly in the most relevant files for their usage.
  - The utils such as `colourLog` has been improved and can now be used for all logging, including errors.
  - The option "debug" is now stored as a global so it can be accessed anywhere without needing to pass it around in each function. 
