### PR TITLE
Added recommended `markdownlint` rule configuration 🍭

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To customise or extend the default rules provided by Lint Pilot or markdownlint,
 
 The default rules set by Lint Pilot are located at `node_modules/lint-pilot/markdownlint.json`. To extend these rules, reference them in your `.markdownlint.json` file and then override or add to them as needed. For example:
 
-```json
+```jsonc
 {
   "extends": "./node_modules/lint-pilot/markdownlint.json",
   "MD013": true, // Enable line length check
@@ -28,7 +28,7 @@ The default rules set by Lint Pilot are located at `node_modules/lint-pilot/mark
 
 If you prefer to start with the default settings from markdownlint, ensure your configuration file includes `"default": true`. This will apply markdownlint's standard rules, which you can then extend or override:
 
-```json
+```jsonc
 {
   "default": true,
   "MD013": false, // Disable line length check

--- a/README.md
+++ b/README.md
@@ -5,3 +5,32 @@
 ## 🚧 Coming Soon
 
 Lint Pilot is currently under construction. Stay tuned for more information.
+
+## Markdown Lint
+
+Lint Pilot integrates with the popular [markdownlint](https://github.com/DavidAnson/markdownlint) plugin to ensure your Markdown files adhere to best practices and your specified style guide.
+
+### Default Rules
+
+Lint Pilot uses a set of default rules for Markdown linting, which can be found [here](./config/markdownlint.json). These rules are designed to cover a wide range of common Markdown issues, providing a solid foundation for most projects.
+
+### Customising Rules
+
+To customise or extend the default rules provided by Lint Pilot or markdownlint, you can create a `.markdownlint.json` file in your project root. This file allows you to modify existing rules or add new ones to fit your project's needs.
+
+The default rules set by Lint Pilot are located at `node_modules/lint-pilot/markdownlint.json`. To extend these rules, reference them in your `.markdownlint.json` file and then override or add to them as needed. For example:
+
+```json
+{
+  "extends": "./node_modules/lint-pilot/markdownlint.json",
+  "MD013": true, // Enable line length check
+}
+
+If you prefer to start with the default settings from markdownlint, ensure your configuration file includes `"default": true`. This will apply markdownlint's standard rules, which you can then extend or override:
+
+```json
+{
+  "default": true,
+  "MD013": false, // Disable line length check
+}
+```

--- a/config/markdownlint.json
+++ b/config/markdownlint.json
@@ -1,3 +1,111 @@
 {
-  "default": true
+  "MD001": true,
+  "MD003": {
+    "style": "atx"
+  },
+  "MD004": {
+    "style": "dash"
+  },
+  "MD005": true,
+  "MD007": {
+    "indent": 2,
+    "start_indent": 2,
+    "start_indented": false
+  },
+  "MD009": {
+    "br_spaces": 2,
+    "list_item_empty_lines": false,
+    "strict": true
+  },
+  "MD010": {
+    "code_blocks": true,
+    "ignore_code_languages": [],
+    "spaces_per_tab": 2
+  },
+  "MD011": true,
+  "MD012": {
+    "maximum": 1
+  },
+  "MD013": false,
+  "MD014": true,
+  "MD018": true,
+  "MD019": true,
+  "MD020": true,
+  "MD021": true,
+  "MD022": {
+    "lines_above": 1,
+    "lines_below": 1
+  },
+  "MD023": true,
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD025": {
+    "level": 1
+  },
+  "MD026": true,
+  "MD027": true,
+  "MD028": true,
+  "MD029": {
+    "style": "ordered"
+  },
+  "MD030": {
+    "ul_single": 1,
+    "ol_single": 1,
+    "ul_multi": 1,
+    "ol_multi": 1
+  },
+  "MD031": {
+    "list_items": true
+  },
+  "MD032": true,
+  "MD033": true,
+  "MD034": true,
+  "MD035": {
+    "style": "---"
+  },
+  "MD036": true,
+  "MD037": true,
+  "MD038": true,
+  "MD039": true,
+  "MD040": true,
+  "MD041": {
+    "level": 1
+  },
+  "MD042": true,
+  "MD043": false,
+  "MD044": {
+    "code_blocks": false,
+    "html_elements": false,
+    "names": [
+      "JavaScript",
+      "Next.js",
+      "Node.js",
+      "Redux",
+      "TypeScript",
+      "Vue.js"
+    ]
+  },
+  "MD045": true,
+  "MD046": {
+    "style": "fenced"
+  },
+  "MD047": true,
+  "MD048": {
+    "style": "backtick"
+  },
+  "MD049": {
+    "style": "underscore"
+  },
+  "MD050": {
+    "style": "asterisk"
+  },
+  "MD051": true,
+  "MD052": true,
+  "MD053": true,
+  "MD054": true,
+  "MD055": {
+    "style": "leading_and_trailing"
+  },
+  "MD056": true
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ program
   .description('Lint Pilot: Your co-pilot for maintaining high code quality with seamless ESLint, Stylelint, and MarkdownLint integration.')
   .version('0.0.1')
   .addHelpText('beforeAll', '\n✈️ Lint Pilot ✈️\n')
-  .showHelpAfterError('\n💡 Run `lint-pilot --help` for more information')
+  .showHelpAfterError('\n💡 Run `lint-pilot --help` for more information.\n')
 
 const runLinter = async ({ filePattern, linter }: RunLinter) => {
   // TODO: Handle case where no files are sourced

--- a/src/linters/markdownlint/__tests__/loadConfig.spec.ts
+++ b/src/linters/markdownlint/__tests__/loadConfig.spec.ts
@@ -20,7 +20,7 @@ describe('loadConfig', () => {
     expect(loadConfig()).toStrictEqual(['custom', {
       default: true,
     }])
-    expect(markdownlint.readConfigSync).toHaveBeenCalledWith(`${process.cwd()}/markdownlint.json`)
+    expect(markdownlint.readConfigSync).toHaveBeenCalledWith(`${process.cwd()}/.markdownlint.json`)
   })
 
   it('returns the development config when NODE_ENV is development', () => {

--- a/src/linters/markdownlint/loadConfig.ts
+++ b/src/linters/markdownlint/loadConfig.ts
@@ -9,7 +9,7 @@ import colourLog from '@Utils/colourLog'
 const loadConfig = (): [string, Configuration] => {
   try {
     // Custom Config
-    const customConfigPath = `${process.cwd()}/markdownlint.json`
+    const customConfigPath = `${process.cwd()}/.markdownlint.json`
     if (fs.existsSync(customConfigPath)) {
       return ['custom', markdownlint.readConfigSync(customConfigPath)]
     }


### PR DESCRIPTION
## Details

### What have you changed?

- Added recommended `markdownlint` rule configuration.
- Added documentation to customise `markdownlint` rule configuration.
- Load custom markdownlint config from `.markdownlint.json`.

### Why are you making these changes?

- So that users can lint their markdown files without requiring additional config - but have the option to re-configure the rules as desired. The default rules provided in Lint Pilot are more strict than the default rules from markdownlint, but are a solid foundation and ensure consistent and well-formatted markdown files.
- Dotfiles (`.gitignore`, `.eslintrc`, etc) is a convention used for configuration files to reduce clutter and differentiate from the project's source code. Therefore `.markdownlint.json` should follow the same pattern.
