### PR TITLE
Configured `eslint-plugin-sort-destructure-keys` 🔑

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,5 +1,6 @@
 ignores: [
   "eslint-plugin-inclusive-language",
+  "eslint-plugin-sort-destructure-keys",
   "rimraf",
   "@types/jest"
 ]

--- a/config/eslint/build-config.ts
+++ b/config/eslint/build-config.ts
@@ -1,11 +1,14 @@
 import InclusiveLanguageRules from './rules/inclusive-language'
+import SortDestructureKeysRules from './rules/sort-destructure-keys'
 
 const buildConfig = () => ({
   plugins: [
     'inclusive-language',
+    'sort-destructure-keys',
   ],
   rules: {
     ...InclusiveLanguageRules,
+    ...SortDestructureKeysRules,
   },
 })
 

--- a/config/eslint/rules/sort-destructure-keys.ts
+++ b/config/eslint/rules/sort-destructure-keys.ts
@@ -1,0 +1,5 @@
+// https://github.com/mthadley/eslint-plugin-sort-destructure-keys
+
+export default {
+  'sort-destructure-keys/sort-destructure-keys': 2,
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "commander": "12.1.0",
     "eslint": "9.4.0",
     "eslint-plugin-inclusive-language": "2.2.1",
+    "eslint-plugin-sort-destructure-keys": "2.0.0",
     "glob": "10.4.1",
     "markdownlint": "0.34.0",
     "node-notifier": "10.0.1",
@@ -54,6 +55,8 @@
   "author": "Patrick Taylor <hello@patricktaylor.dev>",
   "keywords": [
     "eslint",
+    "eslint-plugin-inclusive-language",
+    "eslint-plugin-sort-destructure-keys",
     "lint",
     "markdownlint",
     "stylelint"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2401,6 +2401,13 @@ eslint-plugin-inclusive-language@2.2.1:
   dependencies:
     humps "^2.0.1"
 
+eslint-plugin-sort-destructure-keys@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-2.0.0.tgz#23d26e3db4a8fb73fcd0dfceb2de4c517e6d603f"
+  integrity sha512-4w1UQCa3o/YdfWaLr9jY8LfGowwjwjmwClyFLxIsToiyIdZMq3x9Ti44nDn34DtTPP7PWg96tUONKVmATKhYGQ==
+  dependencies:
+    natural-compare-lite "^1.4.0"
+
 eslint-scope@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-8.0.1.tgz#a9601e4b81a0b9171657c343fb13111688963cfc"
@@ -3639,6 +3646,11 @@ nanoid@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
+
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## Details

### What have you changed?

- Configured `eslint-plugin-sort-destructure-keys`.

### Why are you making these changes?

- This lint plugin requires object destructure key to be sorted which ensures cleaner code which is easier to read and maintain.


