### PR TITLE
Configured `eslint-plugin-sort-exports` ⛴️

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,6 +1,7 @@
 ignores: [
   "eslint-plugin-inclusive-language",
   "eslint-plugin-sort-destructure-keys",
+  "eslint-plugin-sort-exports",
   "rimraf",
   "@types/jest"
 ]

--- a/config/eslint/build-config.ts
+++ b/config/eslint/build-config.ts
@@ -1,14 +1,17 @@
-import InclusiveLanguageRules from './rules/inclusive-language'
-import SortDestructureKeysRules from './rules/sort-destructure-keys'
+import InclusiveLanguage from './rules/inclusive-language'
+import SortDestructureKeys from './rules/sort-destructure-keys'
+import SortExports from './rules/sort-exports'
 
 const buildConfig = () => ({
   plugins: [
     'inclusive-language',
     'sort-destructure-keys',
+    'sort-exports',
   ],
   rules: {
-    ...InclusiveLanguageRules,
-    ...SortDestructureKeysRules,
+    ...InclusiveLanguage,
+    ...SortDestructureKeys,
+    ...SortExports,
   },
 })
 

--- a/config/eslint/rules/sort-exports.ts
+++ b/config/eslint/rules/sort-exports.ts
@@ -1,0 +1,8 @@
+// https://github.com/jrdrg/eslint-plugin-sort-exports
+
+export default {
+  'sort-exports/sort-exports': [2, {
+    sortDir: 'asc',
+    sortExportKindFirst: 'type',
+  }],
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "9.4.0",
     "eslint-plugin-inclusive-language": "2.2.1",
     "eslint-plugin-sort-destructure-keys": "2.0.0",
+    "eslint-plugin-sort-exports": "0.9.1",
     "glob": "10.4.1",
     "markdownlint": "0.34.0",
     "node-notifier": "10.0.1",
@@ -57,6 +58,7 @@
     "eslint",
     "eslint-plugin-inclusive-language",
     "eslint-plugin-sort-destructure-keys",
+    "eslint-plugin-sort-exports",
     "lint",
     "markdownlint",
     "stylelint"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,6 +2408,13 @@ eslint-plugin-sort-destructure-keys@2.0.0:
   dependencies:
     natural-compare-lite "^1.4.0"
 
+eslint-plugin-sort-exports@0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-exports/-/eslint-plugin-sort-exports-0.9.1.tgz#f9641d80d8237e0994bfd9aad38fa8e6d07dfa91"
+  integrity sha512-2w6jHusdF2K60bcGKpa9HEinETwNzVrvplZipVculCfu3ZDd5IW3xL54XVEnVkGIPJnp/LitFCg7owL4DOtuHg==
+  dependencies:
+    minimatch "^9.0.3"
+
 eslint-scope@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-8.0.1.tgz#a9601e4b81a0b9171657c343fb13111688963cfc"
@@ -3624,6 +3631,13 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^9.0.3:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
+  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimatch@^9.0.4:
   version "9.0.4"


### PR DESCRIPTION
## Details

### What have you changed?

- Configured `eslint-plugin-sort-exports`.

### Why are you making these changes?

- This lint plugin requires that exports are sorted alphabetically which ensures cleaner code which is easier to read and maintain.
