### PR TITLE
Process and log results from markdownlint 🦫

### DIFF
--- a/jest-config/setup.ts
+++ b/jest-config/setup.ts
@@ -16,11 +16,9 @@ expect.extend({
       isCalledWithExpected = expected.every((arg, index) => this.equals(received.mock.calls[0][index], arg))
     }
 
-    const pass = isCalledOnce && isCalledWithExpected
-
     return {
       message: () => `expected ${received.getMockName()} to have been called exactly once with "${expected}" but received "${received.mock.calls[0]}"`,
-      pass,
+      pass: isCalledOnce && isCalledWithExpected,
     }
   },
 })

--- a/jest-config/setup.ts
+++ b/jest-config/setup.ts
@@ -1,15 +1,22 @@
+jest.mock('log-symbols', () => ({
+  warning: '!',
+  error: 'X',
+}))
+
 beforeEach(() => {
   global.debug = false
 })
 
 expect.extend({
   toHaveBeenCalledOnceWith(received, ...expected) {
-    const pass = received.mock.calls.length === 1 && received.mock.calls[0].every((arg, index) => {
-      if (typeof arg === 'object' && typeof expected[index] === 'object') {
-        return JSON.stringify(arg) === JSON.stringify(expected[index])
-      }
-      return arg === expected[index]
-    })
+    const isCalledOnce = received.mock.calls.length === 1
+    let isCalledWithExpected = false
+
+    if (isCalledOnce) {
+      isCalledWithExpected = expected.every((arg, index) => this.equals(received.mock.calls[0][index], arg))
+    }
+
+    const pass = isCalledOnce && isCalledWithExpected
 
     return {
       message: () => `expected ${received.getMockName()} to have been called exactly once with "${expected}" but received "${received.mock.calls[0]}"`,

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
     "eslint-plugin-sort-destructure-keys": "2.0.0",
     "eslint-plugin-sort-exports": "0.9.1",
     "glob": "10.4.1",
+    "log-symbols": "6.0.0",
     "markdownlint": "0.34.0",
     "node-notifier": "10.0.1",
+    "space-log": "1.1.1",
     "stylelint": "16.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "log-symbols": "6.0.0",
     "markdownlint": "0.34.0",
     "node-notifier": "10.0.1",
-    "space-log": "1.1.1",
+    "space-log": "1.2.0",
     "stylelint": "16.6.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ const runLinter = async ({ filePattern, linter }: RunLinter) => {
 
   const report: LintReport = await linters[linter].lintFiles(files)
 
-  colourLog.result(report.summary, startTime)
+  colourLog.summary(report.summary, startTime)
 
   return report
 }
@@ -73,7 +73,7 @@ const runLintPilot = ({ title, watch }: RunLintPilot) => {
     })
 
     reports.forEach(({ summary }) => {
-      colourLog.resultBlock(summary)
+      colourLog.summaryBlock(summary)
     })
 
     const exitCode = notifyResults(reports, title)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
-import chalk from 'chalk'
 import { Command } from 'commander'
-import { spaceLog } from 'space-log'
 
 import { Events, Linter } from '@Types'
 import colourLog from '@Utils/colourLog'
@@ -55,21 +53,8 @@ const runLintPilot = ({ title, watch }: RunLintPilot) => {
       linter: Linter.Stylelint,
     }),
   ]).then((reports) => {
-    reports.forEach(({ results, summary }) => {
-      if (Object.keys(results).length === 0) {
-        return
-      }
-
-      colourLog.info(`\nLogging ${summary.linter.toLowerCase()} results:`)
-
-      Object.entries(results).forEach(([file, formattedResults]) => {
-        console.log()
-        console.log(chalk.underline(`${process.cwd()}/${file}`))
-        spaceLog({
-          columnKeys: ['severity', 'position', 'message', 'rule'],
-          spaceSize: 2,
-        }, formattedResults)
-      })
+    reports.forEach(report => {
+      colourLog.results(report)
     })
 
     reports.forEach(({ summary }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
+import chalk from 'chalk'
 import { Command } from 'commander'
+import { spaceLog } from 'space-log'
 
 import { Events, Linter, type LinterResult, type RunLinter, type RunLintPilot } from '@Types'
 import colourLog from '@Utils/colourLog'
@@ -20,7 +22,6 @@ program
   .showHelpAfterError('\n💡 Run `lint-pilot --help` for more information.\n')
 
 const runLinter = async ({ filePattern, linter }: RunLinter) => {
-  // TODO: Handle case where no files are sourced
   const startTime = new Date().getTime()
   colourLog.info(`Running ${linter.toLowerCase()}...`)
 
@@ -52,6 +53,23 @@ const runLintPilot = ({ title, watch }: RunLintPilot) => {
       linter: Linter.Stylelint,
     }),
   ]).then((results) => {
+    results.forEach(({ logs, summary }) => {
+      if (Object.keys(logs).length === 0) {
+        return
+      }
+
+      colourLog.info(`\nLogging ${summary.linter.toLowerCase()} results:`)
+
+      Object.entries(logs).forEach(([file, log]) => {
+        console.log()
+        console.log(chalk.underline(`${process.cwd()}/${file}`))
+        spaceLog({
+          columnKeys: ['type', 'position', 'message', 'rule'],
+          spaceSize: 2,
+        }, log)
+      })
+    })
+
     results.forEach(({ summary }) => {
       colourLog.resultBlock(summary)
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const runLinter = async ({ filePattern, linter }: RunLinter) => {
 
   const result: LinterResult = await linters[linter].lintFiles(files)
 
-  colourLog.result(result.processedResult, startTime)
+  colourLog.result(result.summary, startTime)
 
   return result
 }
@@ -52,8 +52,8 @@ const runLintPilot = ({ title, watch }: RunLintPilot) => {
       linter: Linter.Stylelint,
     }),
   ]).then((results) => {
-    results.forEach(({ processedResult }) => {
-      colourLog.resultBlock(processedResult)
+    results.forEach(({ summary }) => {
+      colourLog.resultBlock(summary)
     })
 
     const exitCode = notifyResults(results, title)

--- a/src/linters/eslint.ts
+++ b/src/linters/eslint.ts
@@ -1,8 +1,8 @@
 import { ESLint } from 'eslint'
 
-import { Linter, type LinterResult, type ResultSummary } from '@Types'
+import { Linter, type LintReport, type ReportSummary } from '@Types'
 
-const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
+const lintFiles = async (files: Array<string>): Promise<LintReport> => {
   try {
     const eslint = new ESLint({
       // @ts-expect-error
@@ -19,7 +19,7 @@ const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
 
     const results = await eslint.lintFiles(files)
 
-    const summary: ResultSummary = {
+    const reportSummary: ReportSummary = {
       deprecatedRules: [],
       errorCount: 0,
       fileCount: results.length,
@@ -30,16 +30,16 @@ const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
     }
 
     results.forEach(({ errorCount, fixableErrorCount, fixableWarningCount, usedDeprecatedRules, warningCount }) => {
-      summary.deprecatedRules = [...new Set([...summary.deprecatedRules, ...usedDeprecatedRules.map(({ ruleId }) => ruleId)])]
-      summary.errorCount += errorCount
-      summary.fixableErrorCount += fixableErrorCount
-      summary.fixableWarningCount += fixableWarningCount
-      summary.warningCount += warningCount
+      reportSummary.deprecatedRules = [...new Set([...reportSummary.deprecatedRules, ...usedDeprecatedRules.map(({ ruleId }) => ruleId)])]
+      reportSummary.errorCount += errorCount
+      reportSummary.fixableErrorCount += fixableErrorCount
+      reportSummary.fixableWarningCount += fixableWarningCount
+      reportSummary.warningCount += warningCount
     })
 
     return {
-      logs: {},
-      summary,
+      results: {},
+      summary: reportSummary,
     }
   } catch (error: any) {
     console.error(error.stack)

--- a/src/linters/eslint.ts
+++ b/src/linters/eslint.ts
@@ -1,6 +1,6 @@
 import { ESLint } from 'eslint'
 
-import { Linter, type LinterResult, type ProcessedResult } from '@Types'
+import { Linter, type LinterResult, type ResultSummary } from '@Types'
 
 const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
   try {
@@ -19,7 +19,7 @@ const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
 
     const results = await eslint.lintFiles(files)
 
-    const processedResult: ProcessedResult = {
+    const summary: ResultSummary = {
       deprecatedRules: [],
       errorCount: 0,
       fileCount: results.length,
@@ -30,15 +30,16 @@ const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
     }
 
     results.forEach(({ errorCount, fixableErrorCount, fixableWarningCount, usedDeprecatedRules, warningCount }) => {
-      processedResult.deprecatedRules = [...new Set([...processedResult.deprecatedRules, ...usedDeprecatedRules.map(({ ruleId }) => ruleId)])]
-      processedResult.errorCount += errorCount
-      processedResult.fixableErrorCount += fixableErrorCount
-      processedResult.fixableWarningCount += fixableWarningCount
-      processedResult.warningCount += warningCount
+      summary.deprecatedRules = [...new Set([...summary.deprecatedRules, ...usedDeprecatedRules.map(({ ruleId }) => ruleId)])]
+      summary.errorCount += errorCount
+      summary.fixableErrorCount += fixableErrorCount
+      summary.fixableWarningCount += fixableWarningCount
+      summary.warningCount += warningCount
     })
 
     return {
-      processedResult,
+      logs: {},
+      summary,
     }
   } catch (error: any) {
     console.error(error.stack)

--- a/src/linters/index.ts
+++ b/src/linters/index.ts
@@ -2,11 +2,11 @@ import eslint from './eslint'
 import stylelint from './stylelint'
 import markdownlint from './markdownlint'
 
-import { Linter, type LinterResult } from '@Types'
+import { Linter, type LintReport } from '@Types'
 
 type Linters = {
   [key in Linter]: {
-    lintFiles: (files: Array<string>) => Promise<LinterResult>
+    lintFiles: (files: Array<string>) => Promise<LintReport>
   }
 }
 

--- a/src/linters/markdownlint/__tests__/index.spec.ts
+++ b/src/linters/markdownlint/__tests__/index.spec.ts
@@ -61,7 +61,7 @@ describe('markdownlint', () => {
     })
 
     expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
-      processedResult: {
+      summary: {
         deprecatedRules: [],
         errorCount: 0,
         fileCount: 1,
@@ -110,7 +110,7 @@ describe('markdownlint', () => {
     })
 
     expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
-      processedResult: {
+      summary: {
         deprecatedRules: [],
         errorCount: 4,
         fileCount: 3,

--- a/src/linters/markdownlint/__tests__/index.spec.ts
+++ b/src/linters/markdownlint/__tests__/index.spec.ts
@@ -67,7 +67,7 @@ describe('markdownlint', () => {
     expect(colourLog.error).toHaveBeenCalledOnceWith('An error occurred while running markdownlint: no results')
   })
 
-  it('resolves with logs and a summary when markdownlint successfully lints (no errors)', async () => {
+  it('resolves with results and a summary when markdownlint successfully lints (no errors)', async () => {
     jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
       callback(null, {
         'README.md': []
@@ -75,7 +75,7 @@ describe('markdownlint', () => {
     })
 
     expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
-      logs: {},
+      results: {},
       summary: {
         deprecatedRules: [],
         errorCount: 0,
@@ -111,6 +111,7 @@ describe('markdownlint', () => {
       'README.md': [{
         ...commonError,
         lineNumber: 7,
+        errorRange: [],
         fixInfo: {
           lineNumber: 7,
         },
@@ -135,48 +136,48 @@ describe('markdownlint', () => {
       })
 
       expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
-        logs: {
+        results: {
           'CHANGELOG.md': [{
-            message: ' test-rule-description: test-error-detail ',
+            message: 'test-rule-description: test-error-detail',
             messageTheme: expect.any(Function),
-            position: ' 1:1 ',
+            position: '1:1',
             positionTheme: expect.any(Function),
-            rule: ' test-rule',
+            rule: 'test-rule',
             ruleTheme: expect.any(Function),
-            type: 'X ',
+            severity: 'X',
           }],
           'README.md': [{
-            message: ' test-rule-description: test-error-detail ',
+            message: 'test-rule-description: test-error-detail',
             messageTheme: expect.any(Function),
-            position: ' 7:1 ',
+            position: '7',
             positionTheme: expect.any(Function),
-            rule: ' test-rule',
+            rule: 'test-rule',
             ruleTheme: expect.any(Function),
-            type: 'X ',
+            severity: 'X',
           }, {
-            message: ' test-rule-description: test-error-detail ',
+            message: 'test-rule-description: test-error-detail',
             messageTheme: expect.any(Function),
-            position: ' 13:1 ',
+            position: '13:1',
             positionTheme: expect.any(Function),
-            rule: ' test-rule-a',
+            rule: 'test-rule-a',
             ruleTheme: expect.any(Function),
-            type: 'X ',
+            severity: 'X',
           }, {
-            message: ' test-rule-description: test-error-detail ',
+            message: 'test-rule-description: test-error-detail',
             messageTheme: expect.any(Function),
-            position: ' 13:1 ',
+            position: '13:1',
             positionTheme: expect.any(Function),
-            rule: ' test-rule-b',
+            rule: 'test-rule-b',
             ruleTheme: expect.any(Function),
-            type: 'X ',
+            severity: 'X',
           }, {
-            message: ' test-rule-description ',
+            message: 'test-rule-description',
             messageTheme: expect.any(Function),
-            position: ' 18:1 ',
+            position: '18:1',
             positionTheme: expect.any(Function),
-            rule: ' test-rule',
+            rule: 'test-rule',
             ruleTheme: expect.any(Function),
-            type: 'X ',
+            severity: 'X',
           }],
         },
         summary: expect.any(Object),
@@ -189,7 +190,7 @@ describe('markdownlint', () => {
       })
 
       expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
-        logs: expect.any(Object),
+        results: expect.any(Object),
         summary: {
           deprecatedRules: [],
           errorCount: 5,

--- a/src/linters/markdownlint/__tests__/index.spec.ts
+++ b/src/linters/markdownlint/__tests__/index.spec.ts
@@ -88,11 +88,10 @@ describe('markdownlint', () => {
     })
   })
 
-  describe('when markdownlint successfully lints (with errors)', () => {
+  it('resolves with results and a summary when markdownlint successfully lints (with errors)', async () => {
 
     const commonError = {
-      ruleNames: ['MD000', 'test-rule'],
-      ruleDescription: 'test-rule-description',
+      ruleNames: ['MD000', 'test-rule-name'],
       ruleInformation: 'test-rule-information',
       errorDetail: 'test-error-detail',
       errorContext: 'test-error-context',
@@ -106,6 +105,7 @@ describe('markdownlint', () => {
         fixInfo: {
           lineNumber: 1,
         },
+        ruleDescription: 'test-rule-description',
       }],
       'CONTRIBUTING.md': [],
       'README.md': [{
@@ -115,93 +115,92 @@ describe('markdownlint', () => {
         fixInfo: {
           lineNumber: 7,
         },
+        ruleDescription: 'no-error-range',
       }, {
         ...commonError,
         errorDetail: '',
-        lineNumber: 18,
+        lineNumber: 9,
+        ruleDescription: 'no-error-detail',
       }, {
         ...commonError,
         lineNumber: 13,
         ruleNames: ['MD000', 'test-rule-b'],
+        ruleDescription: 'sorted-by-name',
       }, {
         ...commonError,
         lineNumber: 13,
         ruleNames: ['MD000', 'test-rule-a'],
+        ruleDescription: 'sorted-by-name',
+      }, {
+        ...commonError,
+        errorDetail: '',
+        lineNumber: 3,
+        ruleDescription: 'sort-by-line-number',
       }],
     }
 
-    it('formats the errors sorted by lineNumber and then alphabetically by ruleName', async () => {
-      jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
-        callback(null, markdownlintResult)
-      })
+    const commonResult = {
+      messageTheme: expect.any(Function),
+      positionTheme: expect.any(Function),
+      ruleTheme: expect.any(Function),
+    }
 
-      expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
-        results: {
-          'CHANGELOG.md': [{
-            message: 'test-rule-description: test-error-detail',
-            messageTheme: expect.any(Function),
-            position: '1:1',
-            positionTheme: expect.any(Function),
-            rule: 'test-rule',
-            ruleTheme: expect.any(Function),
-            severity: 'X',
-          }],
-          'README.md': [{
-            message: 'test-rule-description: test-error-detail',
-            messageTheme: expect.any(Function),
-            position: '7',
-            positionTheme: expect.any(Function),
-            rule: 'test-rule',
-            ruleTheme: expect.any(Function),
-            severity: 'X',
-          }, {
-            message: 'test-rule-description: test-error-detail',
-            messageTheme: expect.any(Function),
-            position: '13:1',
-            positionTheme: expect.any(Function),
-            rule: 'test-rule-a',
-            ruleTheme: expect.any(Function),
-            severity: 'X',
-          }, {
-            message: 'test-rule-description: test-error-detail',
-            messageTheme: expect.any(Function),
-            position: '13:1',
-            positionTheme: expect.any(Function),
-            rule: 'test-rule-b',
-            ruleTheme: expect.any(Function),
-            severity: 'X',
-          }, {
-            message: 'test-rule-description',
-            messageTheme: expect.any(Function),
-            position: '18:1',
-            positionTheme: expect.any(Function),
-            rule: 'test-rule',
-            ruleTheme: expect.any(Function),
-            severity: 'X',
-          }],
-        },
-        summary: expect.any(Object),
-      })
+    jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
+      callback(null, markdownlintResult)
     })
 
-    it('counts fixable errors correctly', async () => {
-      jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
-        callback(null, markdownlintResult)
-      })
-
-      expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
-        results: expect.any(Object),
-        summary: {
-          deprecatedRules: [],
-          errorCount: 5,
-          fileCount: 3,
-          fixableErrorCount: 2,
-          fixableWarningCount: 0,
-          linter: 'MarkdownLint',
-          warningCount: 0,
-        },
-      })
+    expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
+      results: {
+        'CHANGELOG.md': [{
+          ...commonResult,
+          message: 'test-rule-description: test-error-detail',
+          position: '1:1',
+          rule: 'test-rule-name',
+          severity: 'X',
+        }],
+        'README.md': [{
+          ...commonResult,
+          message: 'sort-by-line-number',
+          position: '3:1',
+          rule: 'test-rule-name',
+          severity: 'X',
+        }, {
+          ...commonResult,
+          message: 'no-error-range: test-error-detail',
+          position: '7',
+          rule: 'test-rule-name',
+          severity: 'X',
+        }, {
+          ...commonResult,
+          message: 'no-error-detail',
+          position: '9:1',
+          rule: 'test-rule-name',
+          severity: 'X',
+        }, {
+          ...commonResult,
+          message: 'sorted-by-name: test-error-detail',
+          position: '13:1',
+          rule: 'test-rule-a',
+          severity: 'X',
+        }, {
+          ...commonResult,
+          message: 'sorted-by-name: test-error-detail',
+          position: '13:1',
+          rule: 'test-rule-b',
+          severity: 'X',
+        }],
+      },
+      summary: {
+        deprecatedRules: [],
+        errorCount: 6,
+        fileCount: 3,
+        fixableErrorCount: 2,
+        fixableWarningCount: 0,
+        linter: 'MarkdownLint',
+        warningCount: 0,
+      },
     })
+
   })
 
 })

--- a/src/linters/markdownlint/__tests__/index.spec.ts
+++ b/src/linters/markdownlint/__tests__/index.spec.ts
@@ -21,14 +21,28 @@ describe('markdownlint', () => {
     jest.mocked(loadConfig).mockReturnValue(['default', mockedConfig])
   })
 
-  it('logs the config', async () => {
+  it('loads the config and logs it', async () => {
     jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
       callback(null, {})
     })
 
     await markdownLib.lintFiles(testFiles)
 
+    expect(loadConfig).toHaveBeenCalledTimes(1)
     expect(colourLog.configDebug).toHaveBeenCalledWith('Using default markdownlint config:', mockedConfig)
+  })
+
+  it('calls markdownlint with the config and files', async () => {
+    jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
+      callback(null, {})
+    })
+
+    await markdownLib.lintFiles(testFiles)
+
+    expect(markdownlint).toHaveBeenCalledOnceWith({
+      config: mockedConfig,
+      files: testFiles,
+    }, expect.any(Function))
   })
 
   it('rejects when markdownlint returns an error', async () => {
@@ -38,9 +52,9 @@ describe('markdownlint', () => {
       callback(error, undefined)
     })
 
-    await expect(markdownLib.lintFiles(testFiles)).rejects.toThrow('Test error')
+    await expect(markdownLib.lintFiles(testFiles)).rejects.toThrow(error)
 
-    expect(colourLog.error).toHaveBeenCalledWith('An error occurred while running markdownlint', error)
+    expect(colourLog.error).toHaveBeenCalledOnceWith('An error occurred while running markdownlint', error)
   })
 
   it('rejects when markdownlint returns no results', async () => {
@@ -50,10 +64,10 @@ describe('markdownlint', () => {
 
     await expect(markdownLib.lintFiles(testFiles)).rejects.toThrow('No results')
 
-    expect(colourLog.error).toHaveBeenCalledWith('An error occurred while running markdownlint: no results')
+    expect(colourLog.error).toHaveBeenCalledOnceWith('An error occurred while running markdownlint: no results')
   })
 
-  it('resolves with processed results when markdownlint successfully lints', async () => {
+  it('resolves with logs and a summary when markdownlint successfully lints (no errors)', async () => {
     jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
       callback(null, {
         'README.md': []
@@ -61,6 +75,7 @@ describe('markdownlint', () => {
     })
 
     expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
+      logs: {},
       summary: {
         deprecatedRules: [],
         errorCount: 0,
@@ -73,9 +88,10 @@ describe('markdownlint', () => {
     })
   })
 
-  it('counts fixable errors correctly', async () => {
+  describe('when markdownlint successfully lints (with errors)', () => {
+
     const commonError = {
-      ruleNames: ['test-rule'],
+      ruleNames: ['MD000', 'test-rule'],
       ruleDescription: 'test-rule-description',
       ruleInformation: 'test-rule-information',
       errorDetail: 'test-error-detail',
@@ -83,42 +99,107 @@ describe('markdownlint', () => {
       errorRange: [1, 2],
     }
 
-    jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
-      callback(null, {
-        'CHANGELOG.md': [{
-          ...commonError,
+    const markdownlintResult = {
+      'CHANGELOG.md': [{
+        ...commonError,
+        lineNumber: 1,
+        fixInfo: {
           lineNumber: 1,
-          fixInfo: {
-            lineNumber: 1,
-          },
-        }],
-        'CONTRIBUTING.md': [],
-        'README.md': [{
-          ...commonError,
+        },
+      }],
+      'CONTRIBUTING.md': [],
+      'README.md': [{
+        ...commonError,
+        lineNumber: 7,
+        fixInfo: {
           lineNumber: 7,
-          fixInfo: {
-            lineNumber: 7,
-          },
-        }, {
-          ...commonError,
-          lineNumber: 13,
-        }, {
-          ...commonError,
-          lineNumber: 18,
-        }],
+        },
+      }, {
+        ...commonError,
+        errorDetail: '',
+        lineNumber: 18,
+      }, {
+        ...commonError,
+        lineNumber: 13,
+        ruleNames: ['MD000', 'test-rule-b'],
+      }, {
+        ...commonError,
+        lineNumber: 13,
+        ruleNames: ['MD000', 'test-rule-a'],
+      }],
+    }
+
+    it('formats the errors sorted by lineNumber and then alphabetically by ruleName', async () => {
+      jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
+        callback(null, markdownlintResult)
+      })
+
+      expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
+        logs: {
+          'CHANGELOG.md': [{
+            message: ' test-rule-description: test-error-detail ',
+            messageTheme: expect.any(Function),
+            position: ' 1:1 ',
+            positionTheme: expect.any(Function),
+            rule: ' test-rule',
+            ruleTheme: expect.any(Function),
+            type: 'X ',
+          }],
+          'README.md': [{
+            message: ' test-rule-description: test-error-detail ',
+            messageTheme: expect.any(Function),
+            position: ' 7:1 ',
+            positionTheme: expect.any(Function),
+            rule: ' test-rule',
+            ruleTheme: expect.any(Function),
+            type: 'X ',
+          }, {
+            message: ' test-rule-description: test-error-detail ',
+            messageTheme: expect.any(Function),
+            position: ' 13:1 ',
+            positionTheme: expect.any(Function),
+            rule: ' test-rule-a',
+            ruleTheme: expect.any(Function),
+            type: 'X ',
+          }, {
+            message: ' test-rule-description: test-error-detail ',
+            messageTheme: expect.any(Function),
+            position: ' 13:1 ',
+            positionTheme: expect.any(Function),
+            rule: ' test-rule-b',
+            ruleTheme: expect.any(Function),
+            type: 'X ',
+          }, {
+            message: ' test-rule-description ',
+            messageTheme: expect.any(Function),
+            position: ' 18:1 ',
+            positionTheme: expect.any(Function),
+            rule: ' test-rule',
+            ruleTheme: expect.any(Function),
+            type: 'X ',
+          }],
+        },
+        summary: expect.any(Object),
       })
     })
 
-    expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
-      summary: {
-        deprecatedRules: [],
-        errorCount: 4,
-        fileCount: 3,
-        fixableErrorCount: 2,
-        fixableWarningCount: 0,
-        linter: 'MarkdownLint',
-        warningCount: 0,
-      },
+    it('counts fixable errors correctly', async () => {
+      jest.mocked(markdownlint).mockImplementationOnce((_options, callback) => {
+        callback(null, markdownlintResult)
+      })
+
+      expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
+        logs: expect.any(Object),
+        summary: {
+          deprecatedRules: [],
+          errorCount: 5,
+          fileCount: 3,
+          fixableErrorCount: 2,
+          fixableWarningCount: 0,
+          linter: 'MarkdownLint',
+          warningCount: 0,
+        },
+      })
     })
   })
 

--- a/src/linters/markdownlint/index.ts
+++ b/src/linters/markdownlint/index.ts
@@ -52,7 +52,7 @@ const lintFiles = (files: Array<string>): Promise<LinterResult> => new Promise((
         .sort((a, b) => a.lineNumber - b.lineNumber || a.ruleNames[1].localeCompare(b.ruleNames[1]))
         .forEach(({ errorDetail, errorRange, fixInfo, lineNumber, ruleDescription, ruleNames }) => {
           logs[file].push(formatFileLog({
-            column: errorRange[0],
+            column: errorRange?.length ? errorRange[0] : undefined,
             lineNumber,
             message: errorDetail?.length ? `${ruleDescription}: ${errorDetail}` : ruleDescription,
             rule: ruleNames[1],

--- a/src/linters/markdownlint/index.ts
+++ b/src/linters/markdownlint/index.ts
@@ -1,6 +1,6 @@
 import markdownlint, { type LintResults } from 'markdownlint'
 
-import { Linter, type LinterResult, type ProcessedResult } from '@Types'
+import { Linter, type LinterResult, type ResultLogs, type ResultSummary } from '@Types'
 import colourLog from '@Utils/colourLog'
 
 import loadConfig from './loadConfig'
@@ -24,7 +24,9 @@ const lintFiles = (files: Array<string>): Promise<LinterResult> => new Promise((
       return reject(new Error('No results'))
     }
 
-    const processedResult: ProcessedResult = {
+    const logs: ResultLogs = {}
+
+    const summary: ResultSummary = {
       deprecatedRules: [],
       errorCount: 0,
       fileCount: Object.keys(results).length,
@@ -44,7 +46,8 @@ const lintFiles = (files: Array<string>): Promise<LinterResult> => new Promise((
     })
 
     resolve({
-      processedResult,
+      logs,
+      summary,
     })
   })
 })

--- a/src/linters/stylelint.ts
+++ b/src/linters/stylelint.ts
@@ -1,8 +1,8 @@
 import stylelint from 'stylelint'
 
-import { Linter, type LinterResult, type ResultSummary } from '@Types'
+import { Linter, type LintReport, type ReportSummary } from '@Types'
 
-const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
+const lintFiles = async (files: Array<string>): Promise<LintReport> => {
   try {
     const { results, ruleMetadata } = await stylelint.lint({
       allowEmptyInput: true,
@@ -14,7 +14,7 @@ const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
       files,
     })
 
-    const summary: ResultSummary = {
+    const reportSummary: ReportSummary = {
       deprecatedRules: [],
       errorCount: 0,
       fileCount: results.length,
@@ -25,19 +25,19 @@ const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
     }
 
     results.forEach(({ deprecations, warnings }) => {
-      summary.deprecatedRules = [...new Set([...summary.deprecatedRules, ...deprecations.map(({ text }) => text)])]
-      summary.errorCount += warnings.length
+      reportSummary.deprecatedRules = [...new Set([...reportSummary.deprecatedRules, ...deprecations.map(({ text }) => text)])]
+      reportSummary.errorCount += warnings.length
 
       warnings.forEach(({ rule }) => {
         if (ruleMetadata[rule]?.fixable) {
-          summary.fixableErrorCount += 1
+          reportSummary.fixableErrorCount += 1
         }
       })
     })
 
     return {
-      logs: {},
-      summary,
+      results: {},
+      summary: reportSummary,
     }
   } catch (error: any) {
     console.error(error.stack)

--- a/src/linters/stylelint.ts
+++ b/src/linters/stylelint.ts
@@ -1,6 +1,6 @@
 import stylelint from 'stylelint'
 
-import { Linter, type LinterResult, type ProcessedResult } from '@Types'
+import { Linter, type LinterResult, type ResultSummary } from '@Types'
 
 const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
   try {
@@ -14,7 +14,7 @@ const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
       files,
     })
 
-    const processedResult: ProcessedResult = {
+    const summary: ResultSummary = {
       deprecatedRules: [],
       errorCount: 0,
       fileCount: results.length,
@@ -25,17 +25,19 @@ const lintFiles = async (files: Array<string>): Promise<LinterResult> => {
     }
 
     results.forEach(({ deprecations, warnings }) => {
-      processedResult.deprecatedRules = [...new Set([...processedResult.deprecatedRules, ...deprecations.map(({ text }) => text)])]
-      processedResult.errorCount += warnings.length
+      summary.deprecatedRules = [...new Set([...summary.deprecatedRules, ...deprecations.map(({ text }) => text)])]
+      summary.errorCount += warnings.length
+
       warnings.forEach(({ rule }) => {
         if (ruleMetadata[rule]?.fixable) {
-          processedResult.fixableErrorCount += 1
+          summary.fixableErrorCount += 1
         }
       })
     })
 
     return {
-      processedResult,
+      logs: {},
+      summary,
     }
   } catch (error: any) {
     console.error(error.stack)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,7 +13,7 @@ enum Linter {
 }
 
 /*
- * LINT RESULTS
+ * LINT REPORT
  */
 
 enum RuleSeverity {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,16 @@ enum Linter {
  * LINT RESULTS
  */
 
-interface ProcessedResult {
+interface ResultLogs {
+  [file: string]: Array<{
+    message: string
+    position: string
+    rule: string
+    type: 'error' | 'warning'
+  }>
+}
+
+interface ResultSummary {
   deprecatedRules: Array<string>
   errorCount: number
   fileCount: number
@@ -27,7 +36,8 @@ interface ProcessedResult {
 }
 
 interface LinterResult {
-  processedResult: ProcessedResult
+  logs: ResultLogs
+  summary: ResultSummary
 }
 
 /*
@@ -50,7 +60,8 @@ interface RunLintPilot {
 
 export type {
   LinterResult,
-  ProcessedResult,
+  ResultLogs,
+  ResultSummary,
   RunLinter,
   RunLintPilot,
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,13 +16,23 @@ enum Linter {
  * LINT RESULTS
  */
 
+enum LogType {
+  ERROR = 'error',
+  WARNING = 'warning',
+}
+
+interface FileLog {
+  message: string
+  messageTheme: Function
+  position: string
+  positionTheme: Function
+  rule: string
+  ruleTheme: Function
+  type: string
+}
+
 interface ResultLogs {
-  [file: string]: Array<{
-    message: string
-    position: string
-    rule: string
-    type: 'error' | 'warning'
-  }>
+  [file: string]: Array<FileLog>
 }
 
 interface ResultSummary {
@@ -59,6 +69,7 @@ interface RunLintPilot {
  */
 
 export type {
+  FileLog,
   LinterResult,
   ResultLogs,
   ResultSummary,
@@ -69,4 +80,5 @@ export type {
 export {
   Events,
   Linter,
+  LogType,
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,26 +16,26 @@ enum Linter {
  * LINT RESULTS
  */
 
-enum LogType {
+enum RuleSeverity {
   ERROR = 'error',
   WARNING = 'warning',
 }
 
-interface FileLog {
+interface FormattedResult {
   message: string
   messageTheme: Function
   position: string
   positionTheme: Function
   rule: string
   ruleTheme: Function
-  type: string
+  severity: string
 }
 
-interface ResultLogs {
-  [file: string]: Array<FileLog>
+interface ReportResults {
+  [file: string]: Array<FormattedResult>
 }
 
-interface ResultSummary {
+interface ReportSummary {
   deprecatedRules: Array<string>
   errorCount: number
   fileCount: number
@@ -45,9 +45,9 @@ interface ResultSummary {
   warningCount: number
 }
 
-interface LinterResult {
-  logs: ResultLogs
-  summary: ResultSummary
+interface LintReport {
+  results: ReportResults
+  summary: ReportSummary
 }
 
 /*
@@ -69,10 +69,10 @@ interface RunLintPilot {
  */
 
 export type {
-  FileLog,
-  LinterResult,
-  ResultLogs,
-  ResultSummary,
+  FormattedResult,
+  LintReport,
+  ReportResults,
+  ReportSummary,
   RunLinter,
   RunLintPilot,
 }
@@ -80,5 +80,5 @@ export type {
 export {
   Events,
   Linter,
-  LogType,
+  RuleSeverity,
 }

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 
-import { Linter, type ResultSummary } from '@Types'
+import { Linter, type ReportSummary } from '@Types'
 
 import colourLog from '../colourLog'
 
@@ -117,9 +117,9 @@ describe('colourLog', () => {
 
   })
 
-  describe('result', () => {
+  describe('summary', () => {
 
-    const commonSummary: ResultSummary = {
+    const commonSummary: ReportSummary = {
       deprecatedRules: [],
       errorCount: 0,
       fileCount: 1,
@@ -140,7 +140,7 @@ describe('colourLog', () => {
     }
 
     it('logs the finished lint message along with the file count and duration (single file)', () => {
-      colourLog.result(commonSummary, startTime)
+      colourLog.summary(commonSummary, startTime)
 
       expect(chalk.cyan).toHaveBeenCalledOnceWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledOnceWith('[1 file, 1000ms]')
@@ -148,7 +148,7 @@ describe('colourLog', () => {
     })
 
     it('logs the finished lint message along with the file count and duration (multiple files)', () => {
-      colourLog.result({
+      colourLog.summary({
         ...commonSummary,
         fileCount: 7,
       }, startTime)
@@ -159,7 +159,7 @@ describe('colourLog', () => {
     })
 
     it('logs the error count in red (single error)', () => {
-      colourLog.result({
+      colourLog.summary({
         ...commonSummary,
         errorCount: 1,
       }, startTime)
@@ -170,7 +170,7 @@ describe('colourLog', () => {
     })
 
     it('logs the error count in red (multiple errors)', () => {
-      colourLog.result({
+      colourLog.summary({
         ...commonSummary,
         errorCount: 2,
       }, startTime)
@@ -181,7 +181,7 @@ describe('colourLog', () => {
     })
 
     it('logs the error count in red with the fixable error count in dim', () => {
-      colourLog.result({
+      colourLog.summary({
         ...commonSummary,
         errorCount: 3,
         fixableErrorCount: 2,
@@ -194,7 +194,7 @@ describe('colourLog', () => {
     })
 
     it('logs the warning count in yellow (single warning)', () => {
-      colourLog.result({
+      colourLog.summary({
         ...commonSummary,
         warningCount: 1,
       }, startTime)
@@ -205,7 +205,7 @@ describe('colourLog', () => {
     })
 
     it('logs the warning count in yellow (multiple warnings)', () => {
-      colourLog.result({
+      colourLog.summary({
         ...commonSummary,
         warningCount: 5,
       }, startTime)
@@ -216,7 +216,7 @@ describe('colourLog', () => {
     })
 
     it('logs the warning count in yellow with the fixable warning count in dim', () => {
-      colourLog.result({
+      colourLog.summary({
         ...commonSummary,
         warningCount: 6,
         fixableWarningCount: 3,
@@ -229,7 +229,7 @@ describe('colourLog', () => {
     })
 
     it('logs the deprecated rule count in magenta and the list in dim (single deprecation)', () => {
-      colourLog.result({
+      colourLog.summary({
         ...commonSummary,
         deprecatedRules: ['foo'],
       }, startTime)
@@ -241,7 +241,7 @@ describe('colourLog', () => {
     })
 
     it('logs the deprecated rule count in magenta and the list alphabetised in dim (multiple deprecations)', () => {
-      colourLog.result({
+      colourLog.summary({
         ...commonSummary,
         deprecatedRules: ['foo', 'bar', 'baz'],
       }, startTime)
@@ -253,7 +253,7 @@ describe('colourLog', () => {
     })
 
     it('logs everything together', () => {
-      colourLog.result({
+      colourLog.summary({
         ...commonSummary,
         deprecatedRules: ['foo', 'bar', 'baz'],
         errorCount: 2,
@@ -274,9 +274,9 @@ describe('colourLog', () => {
 
   })
 
-  describe('resultBlock', () => {
+  describe('summaryBlock', () => {
 
-    const commonSummary: ResultSummary = {
+    const commonSummary: ReportSummary = {
       deprecatedRules: [],
       errorCount: 0,
       fileCount: 1,
@@ -287,7 +287,7 @@ describe('colourLog', () => {
     }
 
     it('logs the error count in a red background', () => {
-      colourLog.resultBlock({
+      colourLog.summaryBlock({
         ...commonSummary,
         errorCount: 1,
       })
@@ -297,7 +297,7 @@ describe('colourLog', () => {
     })
 
     it('logs the warning count in a yellow background', () => {
-      colourLog.resultBlock({
+      colourLog.summaryBlock({
         ...commonSummary,
         warningCount: 1,
       })
@@ -307,7 +307,7 @@ describe('colourLog', () => {
     })
 
     it('logs the both the error and warning counts if both are present', () => {
-      colourLog.resultBlock({
+      colourLog.summaryBlock({
         ...commonSummary,
         errorCount: 2,
         warningCount: 3,
@@ -321,7 +321,7 @@ describe('colourLog', () => {
     })
 
     it('logs a success message if there are no errors or warnings', () => {
-      colourLog.resultBlock(commonSummary)
+      colourLog.summaryBlock(commonSummary)
 
       expect(chalk.bgGreen.black).toHaveBeenCalledOnceWith(' ESLint Success! ')
       expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n✅  ESLint Success! ')

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 
-import { Linter, type ProcessedResult } from '@Types'
+import { Linter, type ResultSummary } from '@Types'
 
 import colourLog from '../colourLog'
 
@@ -119,7 +119,7 @@ describe('colourLog', () => {
 
   describe('result', () => {
 
-    const commonResult: ProcessedResult = {
+    const commonSummary: ResultSummary = {
       deprecatedRules: [],
       errorCount: 0,
       fileCount: 1,
@@ -140,7 +140,7 @@ describe('colourLog', () => {
     }
 
     it('logs the finished lint message along with the file count and duration (single file)', () => {
-      colourLog.result(commonResult, startTime)
+      colourLog.result(commonSummary, startTime)
 
       expect(chalk.cyan).toHaveBeenCalledOnceWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledOnceWith('[1 file, 1000ms]')
@@ -149,7 +149,7 @@ describe('colourLog', () => {
 
     it('logs the finished lint message along with the file count and duration (multiple files)', () => {
       colourLog.result({
-        ...commonResult,
+        ...commonSummary,
         fileCount: 7,
       }, startTime)
 
@@ -160,7 +160,7 @@ describe('colourLog', () => {
 
     it('logs the error count in red (single error)', () => {
       colourLog.result({
-        ...commonResult,
+        ...commonSummary,
         errorCount: 1,
       }, startTime)
 
@@ -171,7 +171,7 @@ describe('colourLog', () => {
 
     it('logs the error count in red (multiple errors)', () => {
       colourLog.result({
-        ...commonResult,
+        ...commonSummary,
         errorCount: 2,
       }, startTime)
 
@@ -182,7 +182,7 @@ describe('colourLog', () => {
 
     it('logs the error count in red with the fixable error count in dim', () => {
       colourLog.result({
-        ...commonResult,
+        ...commonSummary,
         errorCount: 3,
         fixableErrorCount: 2,
       }, startTime)
@@ -195,7 +195,7 @@ describe('colourLog', () => {
 
     it('logs the warning count in yellow (single warning)', () => {
       colourLog.result({
-        ...commonResult,
+        ...commonSummary,
         warningCount: 1,
       }, startTime)
 
@@ -206,7 +206,7 @@ describe('colourLog', () => {
 
     it('logs the warning count in yellow (multiple warnings)', () => {
       colourLog.result({
-        ...commonResult,
+        ...commonSummary,
         warningCount: 5,
       }, startTime)
 
@@ -217,7 +217,7 @@ describe('colourLog', () => {
 
     it('logs the warning count in yellow with the fixable warning count in dim', () => {
       colourLog.result({
-        ...commonResult,
+        ...commonSummary,
         warningCount: 6,
         fixableWarningCount: 3,
       }, startTime)
@@ -230,7 +230,7 @@ describe('colourLog', () => {
 
     it('logs the deprecated rule count in magenta and the list in dim (single deprecation)', () => {
       colourLog.result({
-        ...commonResult,
+        ...commonSummary,
         deprecatedRules: ['foo'],
       }, startTime)
 
@@ -242,7 +242,7 @@ describe('colourLog', () => {
 
     it('logs the deprecated rule count in magenta and the list alphabetised in dim (multiple deprecations)', () => {
       colourLog.result({
-        ...commonResult,
+        ...commonSummary,
         deprecatedRules: ['foo', 'bar', 'baz'],
       }, startTime)
 
@@ -254,7 +254,7 @@ describe('colourLog', () => {
 
     it('logs everything together', () => {
       colourLog.result({
-        ...commonResult,
+        ...commonSummary,
         deprecatedRules: ['foo', 'bar', 'baz'],
         errorCount: 2,
         fixableErrorCount: 1,
@@ -276,7 +276,7 @@ describe('colourLog', () => {
 
   describe('resultBlock', () => {
 
-    const commonResult: ProcessedResult = {
+    const commonSummary: ResultSummary = {
       deprecatedRules: [],
       errorCount: 0,
       fileCount: 1,
@@ -288,7 +288,7 @@ describe('colourLog', () => {
 
     it('logs the error count in a red background', () => {
       colourLog.resultBlock({
-        ...commonResult,
+        ...commonSummary,
         errorCount: 1,
       })
 
@@ -298,7 +298,7 @@ describe('colourLog', () => {
 
     it('logs the warning count in a yellow background', () => {
       colourLog.resultBlock({
-        ...commonResult,
+        ...commonSummary,
         warningCount: 1,
       })
 
@@ -308,7 +308,7 @@ describe('colourLog', () => {
 
     it('logs the both the error and warning counts if both are present', () => {
       colourLog.resultBlock({
-        ...commonResult,
+        ...commonSummary,
         errorCount: 2,
         warningCount: 3,
       })
@@ -321,7 +321,7 @@ describe('colourLog', () => {
     })
 
     it('logs a success message if there are no errors or warnings', () => {
-      colourLog.resultBlock(commonResult)
+      colourLog.resultBlock(commonSummary)
 
       expect(chalk.bgGreen.black).toHaveBeenCalledOnceWith(' ESLint Success! ')
       expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n✅  ESLint Success! ')

--- a/src/utils/__tests__/notifier.spec.ts
+++ b/src/utils/__tests__/notifier.spec.ts
@@ -12,7 +12,8 @@ jest.mock('node-notifier', () => ({
 describe('notifyResults', () => {
 
   const generateResult = (errorCount = 0, warningCount = 0): LinterResult => ({
-    processedResult: {
+    logs: {},
+    summary: {
       deprecatedRules: [],
       errorCount,
       fileCount: 0,

--- a/src/utils/__tests__/notifier.spec.ts
+++ b/src/utils/__tests__/notifier.spec.ts
@@ -11,7 +11,7 @@ jest.mock('node-notifier', () => ({
 
 describe('notifyResults', () => {
 
-  const generateResult = (errorCount = 0, warningCount = 0): LintReport => ({
+  const generateReport = (errorCount = 0, warningCount = 0): LintReport => ({
     results: {},
     summary: {
       deprecatedRules: [],
@@ -26,9 +26,9 @@ describe('notifyResults', () => {
 
   it('returns an exit code of 1 if there are errors', () => {
     const exitCode = notifyResults([
-      generateResult(0, 0),
-      generateResult(1, 0),
-      generateResult(0, 1),
+      generateReport(0, 0),
+      generateReport(1, 0),
+      generateReport(0, 1),
     ], 'Lint Pilot')
 
     expect(exitCode).toBe(1)
@@ -36,9 +36,9 @@ describe('notifyResults', () => {
 
   it('returns an exit code of 0 if there are no errors, but there are warnings', () => {
     const exitCode = notifyResults([
-      generateResult(0, 0),
-      generateResult(0, 0),
-      generateResult(0, 1),
+      generateReport(0, 0),
+      generateReport(0, 0),
+      generateReport(0, 1),
     ], 'Lint Pilot')
 
     expect(exitCode).toBe(0)
@@ -46,8 +46,8 @@ describe('notifyResults', () => {
 
   it('returns an exit code of 0 if there are no errors or warnings', () => {
     const exitCode = notifyResults([
-      generateResult(0, 0),
-      generateResult(0, 0),
+      generateReport(0, 0),
+      generateReport(0, 0),
     ], 'Lint Pilot')
 
     expect(exitCode).toBe(0)
@@ -55,9 +55,9 @@ describe('notifyResults', () => {
 
   it('notifies when there is a single error', () => {
     notifyResults([
-      generateResult(0, 0),
-      generateResult(1, 1),
-      generateResult(0, 1),
+      generateReport(0, 0),
+      generateReport(1, 1),
+      generateReport(0, 1),
     ], 'Lint Pilot')
 
     expect(notifier.notify).toHaveBeenCalledOnceWith({
@@ -69,9 +69,9 @@ describe('notifyResults', () => {
 
   it('notifies when there are multiple errors', () => {
     notifyResults([
-      generateResult(0, 0),
-      generateResult(5, 0),
-      generateResult(2, 1),
+      generateReport(0, 0),
+      generateReport(5, 0),
+      generateReport(2, 1),
     ], 'Lint Pilot')
 
     expect(notifier.notify).toHaveBeenCalledOnceWith({
@@ -83,9 +83,9 @@ describe('notifyResults', () => {
 
   it('notifies when there is a single warning', () => {
     notifyResults([
-      generateResult(0, 0),
-      generateResult(0, 0),
-      generateResult(0, 1),
+      generateReport(0, 0),
+      generateReport(0, 0),
+      generateReport(0, 1),
     ], 'Lint Pilot')
 
     expect(notifier.notify).toHaveBeenCalledOnceWith({
@@ -97,9 +97,9 @@ describe('notifyResults', () => {
 
   it('notifies when there are multiple warnings', () => {
     notifyResults([
-      generateResult(0, 0),
-      generateResult(0, 7),
-      generateResult(0, 2),
+      generateReport(0, 0),
+      generateReport(0, 7),
+      generateReport(0, 2),
     ], 'Lint Pilot')
 
     expect(notifier.notify).toHaveBeenCalledOnceWith({
@@ -111,8 +111,8 @@ describe('notifyResults', () => {
 
   it('notifies when there are no errors or warnings', () => {
     notifyResults([
-      generateResult(0, 0),
-      generateResult(0, 0),
+      generateReport(0, 0),
+      generateReport(0, 0),
     ], 'Lint Pilot')
 
     expect(notifier.notify).toHaveBeenCalledOnceWith({

--- a/src/utils/__tests__/notifier.spec.ts
+++ b/src/utils/__tests__/notifier.spec.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals'
 import notifier from 'node-notifier'
 
-import { Linter, type LinterResult } from '@Types'
+import { Linter, type LintReport } from '@Types'
 
 import { notifyResults } from '../notifier'
 
@@ -11,8 +11,8 @@ jest.mock('node-notifier', () => ({
 
 describe('notifyResults', () => {
 
-  const generateResult = (errorCount = 0, warningCount = 0): LinterResult => ({
-    logs: {},
+  const generateResult = (errorCount = 0, warningCount = 0): LintReport => ({
+    results: {},
     summary: {
       deprecatedRules: [],
       errorCount,

--- a/src/utils/__tests__/transform.spec.ts
+++ b/src/utils/__tests__/transform.spec.ts
@@ -1,4 +1,90 @@
-import { pluralise } from '../transform'
+import chalk from 'chalk'
+
+import { LogType } from '@Types'
+
+import { formatFileLog, pluralise } from '../transform'
+
+describe('formatFileLog', () => {
+
+  const commonLog = {
+    column: 1,
+    lineNumber: 1,
+    message: 'This is an error message',
+    rule: 'no-error',
+    type: LogType.ERROR,
+  }
+
+  it('formats the file log with a padded message and theme', () => {
+    const result = formatFileLog(commonLog)
+
+    expect(result).toStrictEqual(expect.objectContaining({
+      message: ' This is an error message ',
+      messageTheme: chalk.white,
+    }))
+  })
+
+  it('truncates the message when it exceeds 72 characters', () => {
+    const result = formatFileLog({
+      ...commonLog,
+      message: 'This is a very long error message. So long that it exceeds 72 characters.',
+    })
+
+    expect(result).toStrictEqual(expect.objectContaining({
+      message: ' This is a very long error message. So long that it exceeds 72 charact... ',
+      messageTheme: chalk.white,
+    }))
+  })
+
+  it('formats the file log with a padded position: line number and column number', () => {
+    const result = formatFileLog(commonLog)
+
+    expect(result).toStrictEqual(expect.objectContaining({
+      position: ' 1:1 ',
+      positionTheme: chalk.dim,
+    }))
+  })
+
+  it('formats the file log with a padded position: only line number', () => {
+    const result = formatFileLog({
+      ...commonLog,
+      column: undefined,
+      lineNumber: 7,
+    })
+
+    expect(result).toStrictEqual(expect.objectContaining({
+      position: ' 7 ',
+      positionTheme: chalk.dim,
+    }))
+  })
+
+  it('formats the file log with a padded rule', () => {
+    const result = formatFileLog(commonLog)
+
+    expect(result).toStrictEqual(expect.objectContaining({
+      rule: ' no-error',
+      ruleTheme: chalk.dim,
+    }))
+  })
+
+  it('formats the file log with padded type for an error', () => {
+    const result = formatFileLog(commonLog)
+
+    expect(result).toStrictEqual(expect.objectContaining({
+      type: 'X ',
+    }))
+  })
+
+  it('formats the file log with padded type for a warning', () => {
+    const result = formatFileLog({
+      ...commonLog,
+      type: LogType.WARNING,
+    })
+
+    expect(result).toStrictEqual(expect.objectContaining({
+      type: '! ',
+    }))
+  })
+})
 
 describe('pluralise', () => {
 

--- a/src/utils/__tests__/transform.spec.ts
+++ b/src/utils/__tests__/transform.spec.ts
@@ -1,87 +1,87 @@
 import chalk from 'chalk'
 
-import { LogType } from '@Types'
+import { RuleSeverity } from '@Types'
 
-import { formatFileLog, pluralise } from '../transform'
+import { formatResult, pluralise } from '../transform'
 
-describe('formatFileLog', () => {
+describe('formatResult', () => {
 
-  const commonLog = {
+  const commonResult = {
     column: 1,
     lineNumber: 1,
     message: 'This is an error message',
     rule: 'no-error',
-    type: LogType.ERROR,
+    severity: RuleSeverity.ERROR,
   }
 
-  it('formats the file log with a padded message and theme', () => {
-    const result = formatFileLog(commonLog)
+  it('formats the result with a message and theme', () => {
+    const formattedResult = formatResult(commonResult)
 
-    expect(result).toStrictEqual(expect.objectContaining({
-      message: ' This is an error message ',
+    expect(formattedResult).toStrictEqual(expect.objectContaining({
+      message: 'This is an error message',
       messageTheme: chalk.white,
     }))
   })
 
   it('truncates the message when it exceeds 72 characters', () => {
-    const result = formatFileLog({
-      ...commonLog,
+    const formattedResult = formatResult({
+      ...commonResult,
       message: 'This is a very long error message. So long that it exceeds 72 characters.',
     })
 
-    expect(result).toStrictEqual(expect.objectContaining({
-      message: ' This is a very long error message. So long that it exceeds 72 charact... ',
+    expect(formattedResult).toStrictEqual(expect.objectContaining({
+      message: 'This is a very long error message. So long that it exceeds 72 charact...',
       messageTheme: chalk.white,
     }))
   })
 
-  it('formats the file log with a padded position: line number and column number', () => {
-    const result = formatFileLog(commonLog)
+  it('formats the result with a position: line number and column number', () => {
+    const formattedResult = formatResult(commonResult)
 
-    expect(result).toStrictEqual(expect.objectContaining({
-      position: ' 1:1 ',
+    expect(formattedResult).toStrictEqual(expect.objectContaining({
+      position: '1:1',
       positionTheme: chalk.dim,
     }))
   })
 
-  it('formats the file log with a padded position: only line number', () => {
-    const result = formatFileLog({
-      ...commonLog,
+  it('formats the result with a position: only line number', () => {
+    const formattedResult = formatResult({
+      ...commonResult,
       column: undefined,
       lineNumber: 7,
     })
 
-    expect(result).toStrictEqual(expect.objectContaining({
-      position: ' 7 ',
+    expect(formattedResult).toStrictEqual(expect.objectContaining({
+      position: '7',
       positionTheme: chalk.dim,
     }))
   })
 
-  it('formats the file log with a padded rule', () => {
-    const result = formatFileLog(commonLog)
+  it('formats the result with a rule', () => {
+    const formattedResult = formatResult(commonResult)
 
-    expect(result).toStrictEqual(expect.objectContaining({
-      rule: ' no-error',
+    expect(formattedResult).toStrictEqual(expect.objectContaining({
+      rule: 'no-error',
       ruleTheme: chalk.dim,
     }))
   })
 
-  it('formats the file log with padded type for an error', () => {
-    const result = formatFileLog(commonLog)
+  it('formats the result with a rule severity of error', () => {
+    const formattedResult = formatResult(commonResult)
 
-    expect(result).toStrictEqual(expect.objectContaining({
-      type: 'X ',
+    expect(formattedResult).toStrictEqual(expect.objectContaining({
+      severity: 'X',
     }))
   })
 
-  it('formats the file log with padded type for a warning', () => {
-    const result = formatFileLog({
-      ...commonLog,
-      type: LogType.WARNING,
+  it('formats the result with a rule severity of warning', () => {
+    const formattedResult = formatResult({
+      ...commonResult,
+      severity: RuleSeverity.WARNING,
     })
 
-    expect(result).toStrictEqual(expect.objectContaining({
-      type: '! ',
+    expect(formattedResult).toStrictEqual(expect.objectContaining({
+      severity: '!',
     }))
   })
 })

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 
 import { pluralise } from '@Utils/transform'
 
-import type { ResultSummary } from '@Types'
+import type { ReportSummary } from '@Types'
 
 const colourLog = {
   config: (key: string, configArray: Array<string>) => {
@@ -29,7 +29,7 @@ const colourLog = {
 
   info: (text: string) => console.log(chalk.blue(text)),
 
-  result: (summary: ResultSummary, startTime: number) => {
+  summary: (summary: ReportSummary, startTime: number) => {
     const { deprecatedRules, errorCount, fileCount, fixableErrorCount, fixableWarningCount, linter, warningCount } = summary
 
     const log = []
@@ -71,7 +71,7 @@ const colourLog = {
     }
   },
 
-  resultBlock: ({ errorCount, linter, warningCount }: ResultSummary) => {
+  summaryBlock: ({ errorCount, linter, warningCount }: ReportSummary) => {
     // Errors
     if (errorCount > 0) {
       const message = chalk.bgRed.black(` ${errorCount} ${linter} ${pluralise('Error', errorCount)} `)

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -1,8 +1,9 @@
 import chalk from 'chalk'
+import { spaceLog } from 'space-log'
 
 import { pluralise } from '@Utils/transform'
 
-import type { ReportSummary } from '@Types'
+import type { LintReport, ReportSummary } from '@Types'
 
 const colourLog = {
   config: (key: string, configArray: Array<string>) => {
@@ -28,6 +29,23 @@ const colourLog = {
   },
 
   info: (text: string) => console.log(chalk.blue(text)),
+
+  results: ({ results, summary }: LintReport) => {
+    if (Object.keys(results).length === 0) {
+      return
+    }
+
+    console.log(chalk.blue(`\nLogging ${summary.linter.toLowerCase()} results:`))
+
+    Object.entries(results).forEach(([file, formattedResults]) => {
+      console.log()
+      console.log(chalk.underline(`${process.cwd()}/${file}`))
+      spaceLog({
+        columnKeys: ['severity', 'position', 'message', 'rule'],
+        spaceSize: 2,
+      }, formattedResults)
+    })
+  },
 
   summary: (summary: ReportSummary, startTime: number) => {
     const { deprecatedRules, errorCount, fileCount, fixableErrorCount, fixableWarningCount, linter, warningCount } = summary

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 
 import { pluralise } from '@Utils/transform'
 
-import type { ProcessedResult } from '@Types'
+import type { ResultSummary } from '@Types'
 
 const colourLog = {
   config: (key: string, configArray: Array<string>) => {
@@ -29,8 +29,8 @@ const colourLog = {
 
   info: (text: string) => console.log(chalk.blue(text)),
 
-  result: (processedResult: ProcessedResult, startTime: number) => {
-    const { deprecatedRules, errorCount, fileCount, fixableErrorCount, fixableWarningCount, linter, warningCount } = processedResult
+  result: (summary: ResultSummary, startTime: number) => {
+    const { deprecatedRules, errorCount, fileCount, fixableErrorCount, fixableWarningCount, linter, warningCount } = summary
 
     const log = []
 
@@ -71,7 +71,7 @@ const colourLog = {
     }
   },
 
-  resultBlock: ({ errorCount, linter, warningCount }: ProcessedResult) => {
+  resultBlock: ({ errorCount, linter, warningCount }: ResultSummary) => {
     // Errors
     if (errorCount > 0) {
       const message = chalk.bgRed.black(` ${errorCount} ${linter} ${pluralise('Error', errorCount)} `)

--- a/src/utils/notifier.ts
+++ b/src/utils/notifier.ts
@@ -6,7 +6,7 @@ import type { LinterResult } from '@Types'
 
 const notifyResults = (results: Array<LinterResult>, title: string) => {
   // Errors
-  let totalErrorCount = results.reduce((total, { processedResult: { errorCount } }) => total + errorCount, 0)
+  let totalErrorCount = results.reduce((total, { summary: { errorCount } }) => total + errorCount, 0)
   if (totalErrorCount > 0) {
     notifier.notify({
       message: `${totalErrorCount} ${pluralise('error', totalErrorCount)} found. Please fix ${totalErrorCount > 1 ? 'them ' : 'it '}before continuing.`,
@@ -17,7 +17,7 @@ const notifyResults = (results: Array<LinterResult>, title: string) => {
   }
 
   // Warnings
-  let totalWarningCount = results.reduce((total, { processedResult: { warningCount } }) => total + warningCount, 0)
+  let totalWarningCount = results.reduce((total, { summary: { warningCount } }) => total + warningCount, 0)
   if (totalWarningCount > 0) {
     notifier.notify({
       message: `${totalWarningCount} ${pluralise('warning', totalWarningCount)} found. Please review ${totalWarningCount > 1 ? 'them ' : ''}before continuing.`,

--- a/src/utils/notifier.ts
+++ b/src/utils/notifier.ts
@@ -4,9 +4,9 @@ import { pluralise } from '@Utils/transform'
 
 import type { LintReport } from '@Types'
 
-const notifyResults = (results: Array<LintReport>, title: string) => {
+const notifyResults = (reports: Array<LintReport>, title: string) => {
   // Errors
-  let totalErrorCount = results.reduce((total, { summary: { errorCount } }) => total + errorCount, 0)
+  let totalErrorCount = reports.reduce((total, { summary: { errorCount } }) => total + errorCount, 0)
   if (totalErrorCount > 0) {
     notifier.notify({
       message: `${totalErrorCount} ${pluralise('error', totalErrorCount)} found. Please fix ${totalErrorCount > 1 ? 'them ' : 'it '}before continuing.`,
@@ -17,7 +17,7 @@ const notifyResults = (results: Array<LintReport>, title: string) => {
   }
 
   // Warnings
-  let totalWarningCount = results.reduce((total, { summary: { warningCount } }) => total + warningCount, 0)
+  let totalWarningCount = reports.reduce((total, { summary: { warningCount } }) => total + warningCount, 0)
   if (totalWarningCount > 0) {
     notifier.notify({
       message: `${totalWarningCount} ${pluralise('warning', totalWarningCount)} found. Please review ${totalWarningCount > 1 ? 'them ' : ''}before continuing.`,

--- a/src/utils/notifier.ts
+++ b/src/utils/notifier.ts
@@ -2,9 +2,9 @@ import notifier from 'node-notifier'
 
 import { pluralise } from '@Utils/transform'
 
-import type { LinterResult } from '@Types'
+import type { LintReport } from '@Types'
 
-const notifyResults = (results: Array<LinterResult>, title: string) => {
+const notifyResults = (results: Array<LintReport>, title: string) => {
   // Errors
   let totalErrorCount = results.reduce((total, { summary: { errorCount } }) => total + errorCount, 0)
   if (totalErrorCount > 0) {

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -11,21 +11,15 @@ interface ProcessLog {
   type: LogType
 }
 
-const formatFileLog = ({ column, lineNumber, message, rule, type }: ProcessLog): FileLog => {
-  const logMessage = message.length > 72 ? `${message.substring(0, 69)}...` : message
-  const logPosition = column ? `${lineNumber}:${column}` : lineNumber
-  const typeSymbol = type === LogType.WARNING ? logSymbols.warning : logSymbols.error
-
-  return {
-    message: ` ${logMessage} `,
-    messageTheme: chalk.white,
-    position: ` ${logPosition} `,
-    positionTheme: chalk.dim,
-    rule: ` ${rule}`,
-    ruleTheme: chalk.dim,
-    type: `${typeSymbol} `,
-  }
-}
+const formatFileLog = ({ column, lineNumber, message, rule, type }: ProcessLog): FileLog => ({
+  message: message.length > 72 ? `${message.substring(0, 69)}...` : message,
+  messageTheme: chalk.white,
+  position: column ? `${lineNumber}:${column}` : lineNumber.toString(),
+  positionTheme: chalk.dim,
+  rule: rule,
+  ruleTheme: chalk.dim,
+  type: type === LogType.WARNING ? logSymbols.warning : logSymbols.error,
+})
 
 const pluralise = (word: string, count: number) => count === 1 ? word : `${word}s`
 

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -1,29 +1,29 @@
 import chalk from 'chalk'
 import logSymbols from 'log-symbols'
 
-import { type FileLog, LogType } from '@Types'
+import { type FormattedResult, RuleSeverity } from '@Types'
 
-interface ProcessLog {
+interface Result {
   column?: number
   lineNumber: number
   message: string
   rule: string
-  type: LogType
+  severity: RuleSeverity
 }
 
-const formatFileLog = ({ column, lineNumber, message, rule, type }: ProcessLog): FileLog => ({
+const formatResult = ({ column, lineNumber, message, rule, severity }: Result): FormattedResult => ({
   message: message.length > 72 ? `${message.substring(0, 69)}...` : message,
   messageTheme: chalk.white,
   position: column ? `${lineNumber}:${column}` : lineNumber.toString(),
   positionTheme: chalk.dim,
   rule: rule,
   ruleTheme: chalk.dim,
-  type: type === LogType.WARNING ? logSymbols.warning : logSymbols.error,
+  severity: severity === RuleSeverity.WARNING ? logSymbols.warning : logSymbols.error,
 })
 
 const pluralise = (word: string, count: number) => count === 1 ? word : `${word}s`
 
 export {
-  formatFileLog,
+  formatResult,
   pluralise,
 }

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -1,5 +1,35 @@
+import chalk from 'chalk'
+import logSymbols from 'log-symbols'
+
+import { type FileLog, LogType } from '@Types'
+
+interface ProcessLog {
+  column?: number
+  lineNumber: number
+  message: string
+  rule: string
+  type: LogType
+}
+
+const formatFileLog = ({ column, lineNumber, message, rule, type }: ProcessLog): FileLog => {
+  const logMessage = message.length > 72 ? `${message.substring(0, 69)}...` : message
+  const logPosition = column ? `${lineNumber}:${column}` : lineNumber
+  const typeSymbol = type === LogType.WARNING ? logSymbols.warning : logSymbols.error
+
+  return {
+    message: ` ${logMessage} `,
+    messageTheme: chalk.white,
+    position: ` ${logPosition} `,
+    positionTheme: chalk.dim,
+    rule: ` ${rule}`,
+    ruleTheme: chalk.dim,
+    type: `${typeSymbol} `,
+  }
+}
+
 const pluralise = (word: string, count: number) => count === 1 ? word : `${word}s`
 
 export {
+  formatFileLog,
   pluralise,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2077,7 +2077,15 @@ caniuse-lite@^1.0.30001629:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001632.tgz#964207b7cba5851701afb4c8afaf1448db3884b6"
   integrity sha512-udx3o7yHJfUxMLkGohMlVHCvFvWmirKh9JAH/d7WOLPetlH+LTL5cocMZ0t7oZx/mdlOWXti97xLZWc8uURRHg==
 
-chalk@5.3.0:
+chalk@4.1.2, chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@5.3.0, chalk@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
@@ -2090,14 +2098,6 @@ chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -2937,6 +2937,11 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
+is-unicode-supported@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz#d824984b616c292a2e198207d4a609983842f714"
+  integrity sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==
+
 is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
@@ -3518,6 +3523,14 @@ lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
+
+log-symbols@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-6.0.0.tgz#bb95e5f05322651cac30c0feb6404f9f2a8a9439"
+  integrity sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==
+  dependencies:
+    chalk "^5.3.0"
+    is-unicode-supported "^1.3.0"
 
 lru-cache@^10.2.0:
   version "10.2.2"
@@ -4165,6 +4178,13 @@ source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+space-log@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/space-log/-/space-log-1.1.1.tgz#13418b8ea43bcd0e8bc14598ed68cea9972f00f7"
+  integrity sha512-Snf4o+ZU8P3zSl3sFNY9Tg7229eEsmvPCoMBCcK3Kvk5eB905IGGcMTuTkqMTV7BzmFmca12tKI6rbf5rObgMg==
+  dependencies:
+    chalk "4.1.2"
 
 sprintf-js@~1.0.2:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4179,10 +4179,10 @@ source-map@^0.6.0, source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-space-log@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/space-log/-/space-log-1.1.1.tgz#13418b8ea43bcd0e8bc14598ed68cea9972f00f7"
-  integrity sha512-Snf4o+ZU8P3zSl3sFNY9Tg7229eEsmvPCoMBCcK3Kvk5eB905IGGcMTuTkqMTV7BzmFmca12tKI6rbf5rObgMg==
+space-log@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/space-log/-/space-log-1.2.0.tgz#78fadb50e60a2714b0fb021472c597bb852af6f7"
+  integrity sha512-pG5HTbC7DCNa2U3QYIzDWl64xmX7cvI2lu4r4EXhKeKwSM7m61E9ZmRzQctGAZDvB73p5iniYb2plCtnHn0FOA==
   dependencies:
     chalk "4.1.2"
 


### PR DESCRIPTION
## Details

### What have you changed?

- Process the lint results from `markdownlint` and log them in the console in a nicely formatted structure.

### Why are you making these changes?

- So that users can review the errors from `markdownlint` in a simple and easy-to-read format.
