### PR TITLE
Configured `eslint-plugin-eslint-comments` 💬

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,8 +1,9 @@
 ignores: [
+  "eslint-plugin-eslint-comments",
   "eslint-plugin-inclusive-language",
   "eslint-plugin-sort-destructure-keys",
   "eslint-plugin-sort-exports",
-  "rimraf",
-  "@types/jest"
+  "@types/jest",
+  "rimraf"
 ]
 skip-missing: true

--- a/config/eslint/build-config.ts
+++ b/config/eslint/build-config.ts
@@ -1,14 +1,17 @@
+import ESLintComments from './rules/eslint-comments'
 import InclusiveLanguage from './rules/inclusive-language'
 import SortDestructureKeys from './rules/sort-destructure-keys'
 import SortExports from './rules/sort-exports'
 
 const buildConfig = () => ({
   plugins: [
+    'eslint-comments',
     'inclusive-language',
     'sort-destructure-keys',
     'sort-exports',
   ],
   rules: {
+    ...ESLintComments,
     ...InclusiveLanguage,
     ...SortDestructureKeys,
     ...SortExports,

--- a/config/eslint/rules/eslint-comments.ts
+++ b/config/eslint/rules/eslint-comments.ts
@@ -1,0 +1,21 @@
+// https://github.com/mysticatea/eslint-plugin-eslint-comments
+
+const bestPractices = {
+  'eslint-comments/disable-enable-pair': [2, { allowWholeFile: true }],
+  'eslint-comments/no-aggregating-enable': 2,
+  'eslint-comments/no-duplicate-disable': 2,
+  'eslint-comments/no-unlimited-disable': 2,
+  'eslint-comments/no-unused-disable': 2,
+  'eslint-comments/no-unused-enable': 2,
+}
+
+const stylisticIssues = {
+  'eslint-comments/no-restricted-disable': 0,
+  'eslint-comments/no-use': 0,
+  'eslint-comments/require-description': 0,
+}
+
+export default {
+  ...bestPractices,
+  ...stylisticIssues,
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chokidar": "3.6.0",
     "commander": "12.1.0",
     "eslint": "9.4.0",
+    "eslint-plugin-eslint-comments": "3.2.0",
     "eslint-plugin-inclusive-language": "2.2.1",
     "eslint-plugin-sort-destructure-keys": "2.0.0",
     "eslint-plugin-sort-exports": "0.9.1",
@@ -58,6 +59,7 @@
   "author": "Patrick Taylor <hello@patricktaylor.dev>",
   "keywords": [
     "eslint",
+    "eslint-plugin-eslint-comments",
     "eslint-plugin-inclusive-language",
     "eslint-plugin-sort-destructure-keys",
     "eslint-plugin-sort-exports",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2394,6 +2394,14 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+eslint-plugin-eslint-comments@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz#9e1cd7b4413526abb313933071d7aba05ca12ffa"
+  integrity sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 eslint-plugin-inclusive-language@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-inclusive-language/-/eslint-plugin-inclusive-language-2.2.1.tgz#6cc0f70b10236e2709818f26140a2cbf2c82c041"
@@ -2827,7 +2835,7 @@ humps@^2.0.1:
   resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
   integrity sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==
 
-ignore@^5.2.0, ignore@^5.3.1:
+ignore@^5.0.5, ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==


### PR DESCRIPTION
## Details

### What have you changed?

- Configured `eslint-plugin-eslint-comments`.

### Why are you making these changes?

- This lint plugin is useful to not disable more lint rules than are needed, and to not have unused eslint directive comments (`eslint-disable`) lingering in the codebase.
