### PR TITLE
Process and log results from ESLint 🦎

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.4]
 
     steps:
     - name: Checkout Repository

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,6 @@
+export default [{
+  rules: {
+    quotes: [2, 'single'],
+    semi: [2, 'never'],
+  },
+}]

--- a/jest-config/setup.ts
+++ b/jest-config/setup.ts
@@ -3,6 +3,10 @@ jest.mock('log-symbols', () => ({
   error: 'X',
 }))
 
+jest.spyOn(process, 'exit').mockImplementation(code => {
+  throw new Error(`process.exit(${code})`)
+})
+
 beforeEach(() => {
   global.debug = false
 })

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,7 +8,7 @@ const config: JestConfigWithTsJest = {
     'src/**/*.ts',
     // TODO: Write tests for these files when they are less likely to change
     '!src/index.ts',
-    '!src/linters/(eslint|index|stylelint).ts',
+    '!src/linters/(index|stylelint).ts',
   ],
   coverageDirectory: 'coverage',
   coverageThreshold: {

--- a/src/__tests__/sourceFiles.spec.ts
+++ b/src/__tests__/sourceFiles.spec.ts
@@ -11,7 +11,6 @@ describe('sourceFiles', () => {
 
   jest.spyOn(colourLog, 'configDebug').mockImplementation(() => {})
   jest.spyOn(colourLog, 'error').mockImplementation(() => {})
-  jest.spyOn(process, 'exit').mockImplementation(() => null as never)
 
   const commonArgs = {
     filePattern: '*.ts',
@@ -54,14 +53,18 @@ describe('sourceFiles', () => {
   })
 
   it('catches any errors and exists the process', async () => {
+    expect.assertions(2)
+
     const error = new Error('Test error')
 
     jest.mocked(glob).mockRejectedValue(error)
 
-    await sourceFiles(commonArgs)
-
-    expect(colourLog.error).toHaveBeenCalledWith('An error occurred while trying to source files matching *.ts', error)
-    expect(process.exit).toHaveBeenCalledWith(1)
+    try {
+      await sourceFiles(commonArgs)
+    } catch {
+      expect(colourLog.error).toHaveBeenCalledWith('An error occurred while trying to source files matching *.ts', error)
+      expect(process.exit).toHaveBeenCalledWith(1)
+    }
   })
 
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,4 +111,8 @@ program
     }
   })
 
+process.on('exit', () => {
+  console.log()
+})
+
 program.parse(process.argv)

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,10 @@ const runLinter = async ({ filePattern, linter }: RunLinter) => {
 
   const files = await sourceFiles({
     filePattern,
-    ignore: '**/+(coverage|node_modules)/**',
+    ignore: [
+      '**/*.min.*',
+      '**/+(coverage|node_modules)/**',
+    ],
     linter,
   })
 
@@ -93,7 +96,10 @@ program
           '**/*.{md,mdx}',
           '**/*.{css,scss,less,sass,styl,stylus}',
         ],
-        ignorePatterns: ['**/+(coverage|node_modules)/**'],
+        ignorePatterns: [
+          '**/*.min.*',
+          '**/+(coverage|node_modules)/**',
+        ],
       })
 
       fileChangeEvent.on(Events.FILE_CHANGED, ({ message }) => {

--- a/src/linters/__tests__/eslint.spec.ts
+++ b/src/linters/__tests__/eslint.spec.ts
@@ -19,26 +19,24 @@ describe('eslint', () => {
 
     await eslintLib.lintFiles(testFiles)
 
-    expect(ESLint).toHaveBeenCalledTimes(1)
-    expect(ESLint).toHaveBeenCalledWith({
+    expect(ESLint).toHaveBeenCalledOnceWith({
       cache: false,
       fix: false,
     })
   })
 
-  it('calls eslint with the files', async () => {
+  it('calls ESLint.lintFiles with the files', async () => {
     lintFilesMock.mockImplementationOnce(() => [])
 
     await eslintLib.lintFiles(testFiles)
 
-    expect(ESLint.prototype.lintFiles).toHaveBeenCalledTimes(1)
-    expect(ESLint.prototype.lintFiles).toHaveBeenCalledWith(testFiles)
+    expect(ESLint.prototype.lintFiles).toHaveBeenCalledOnceWith(testFiles)
   })
 
   it('exists the process when eslint throws an error', async () => {
     expect.assertions(2)
 
-    const error = new Error('Test error') as any
+    const error = new Error('Test error')
 
     lintFilesMock.mockImplementationOnce(() => {
       throw error
@@ -50,6 +48,25 @@ describe('eslint', () => {
       expect(colourLog.error).toHaveBeenCalledOnceWith('An error occurred while running eslint', error)
       expect(process.exit).toHaveBeenCalledWith(1)
     }
+  })
+
+  it('resolves with results and a summary when eslint successfully lints (no files)', async () => {
+    const lintResults: Array<ESLint.LintResult> = []
+
+    lintFilesMock.mockImplementationOnce(() => lintResults)
+
+    expect(await eslintLib.lintFiles(testFiles)).toStrictEqual({
+      results: {},
+      summary: {
+        deprecatedRules: [],
+        errorCount: 0,
+        fileCount: 0,
+        fixableErrorCount: 0,
+        fixableWarningCount: 0,
+        linter: 'ESLint',
+        warningCount: 0,
+      },
+    })
   })
 
   it('resolves with results and a summary when eslint successfully lints (no errors)', async () => {
@@ -82,7 +99,7 @@ describe('eslint', () => {
   })
 
   it('resolves with results and a summary when eslint successfully lints (with errors, warnings, and deprecations)', async () => {
-    const lintResults: Array<ESLint.LintResult> = [{
+    const eslintResult: Array<ESLint.LintResult> = [{
       errorCount: 0,
       fatalErrorCount: 0,
       filePath: `${process.cwd()}/constants.ts`,
@@ -153,7 +170,7 @@ describe('eslint', () => {
       ruleTheme: expect.any(Function),
     }
 
-    lintFilesMock.mockImplementationOnce(() => lintResults)
+    lintFilesMock.mockImplementationOnce(() => eslintResult)
 
     expect(await eslintLib.lintFiles(testFiles)).toStrictEqual({
       results: {
@@ -194,5 +211,7 @@ describe('eslint', () => {
         warningCount: 2,
       },
     })
+
   })
+
 })

--- a/src/linters/__tests__/eslint.spec.ts
+++ b/src/linters/__tests__/eslint.spec.ts
@@ -1,0 +1,198 @@
+import { ESLint } from 'eslint'
+
+import colourLog from '@Utils/colourLog'
+
+import eslintLib from '../eslint'
+
+jest.mock('eslint')
+jest.mock('@Utils/colourLog')
+
+describe('eslint', () => {
+
+  jest.spyOn(colourLog, 'error').mockImplementation(() => {})
+
+  const testFiles = ['index.ts']
+  const lintFilesMock = ESLint.prototype.lintFiles as jest.Mock
+
+  it('creates a new ESLint instance', async () => {
+    lintFilesMock.mockImplementationOnce(() => [])
+
+    await eslintLib.lintFiles(testFiles)
+
+    expect(ESLint).toHaveBeenCalledTimes(1)
+    expect(ESLint).toHaveBeenCalledWith({
+      cache: false,
+      fix: false,
+    })
+  })
+
+  it('calls eslint with the files', async () => {
+    lintFilesMock.mockImplementationOnce(() => [])
+
+    await eslintLib.lintFiles(testFiles)
+
+    expect(ESLint.prototype.lintFiles).toHaveBeenCalledTimes(1)
+    expect(ESLint.prototype.lintFiles).toHaveBeenCalledWith(testFiles)
+  })
+
+  it('exists the process when eslint throws an error', async () => {
+    expect.assertions(2)
+
+    const error = new Error('Test error') as any
+
+    lintFilesMock.mockImplementationOnce(() => {
+      throw error
+    })
+
+    try {
+      await eslintLib.lintFiles(testFiles)
+    } catch {
+      expect(colourLog.error).toHaveBeenCalledOnceWith('An error occurred while running eslint', error)
+      expect(process.exit).toHaveBeenCalledWith(1)
+    }
+  })
+
+  it('resolves with results and a summary when eslint successfully lints (no errors)', async () => {
+    const lintResults: Array<ESLint.LintResult> = [{
+      errorCount: 0,
+      fatalErrorCount: 0,
+      filePath: `${process.cwd()}/index.ts`,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0,
+      messages: [],
+      suppressedMessages: [],
+      usedDeprecatedRules: [],
+      warningCount: 0,
+    }]
+
+    lintFilesMock.mockImplementationOnce(() => lintResults)
+
+    expect(await eslintLib.lintFiles(testFiles)).toStrictEqual({
+      results: {},
+      summary: {
+        deprecatedRules: [],
+        errorCount: 0,
+        fileCount: 1,
+        fixableErrorCount: 0,
+        fixableWarningCount: 0,
+        linter: 'ESLint',
+        warningCount: 0,
+      },
+    })
+  })
+
+  it('resolves with results and a summary when eslint successfully lints (with errors, warnings, and deprecations)', async () => {
+    const lintResults: Array<ESLint.LintResult> = [{
+      errorCount: 0,
+      fatalErrorCount: 0,
+      filePath: `${process.cwd()}/constants.ts`,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0,
+      messages: [],
+      suppressedMessages: [],
+      usedDeprecatedRules: [],
+      warningCount: 0,
+    }, {
+      errorCount: 4,
+      fatalErrorCount: 0,
+      filePath: `${process.cwd()}/index.ts`,
+      fixableErrorCount: 3,
+      fixableWarningCount: 1,
+      messages: [{
+        column: 1,
+        line: 1,
+        message: 'Normal rule error',
+        ruleId: 'normal-error',
+        severity: 2,
+      }, {
+        column: 1,
+        line: 2,
+        message: 'Normal rule warning',
+        ruleId: 'normal-warning',
+        severity: 1,
+      }, {
+        column: 1,
+        line: 3,
+        message: 'Error with trailing whitespace ',
+        ruleId: 'spaced-error',
+        severity: 2,
+      }],
+      suppressedMessages: [],
+      usedDeprecatedRules: [{
+        ruleId: 'deprecated-rule-1',
+        replacedBy: ['new-rule-1'],
+      }],
+      warningCount: 2,
+    }, {
+      errorCount: 1,
+      fatalErrorCount: 0,
+      filePath: `${process.cwd()}/utils.ts`,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0,
+      // @ts-expect-error - line is required, but for ignored files it is not provided
+      messages: [{
+        column: 1,
+        message: 'Test core error',
+        ruleId: null,
+        severity: 1,
+      }],
+      suppressedMessages: [],
+      usedDeprecatedRules: [{
+        ruleId: 'deprecated-rule-1',
+        replacedBy: ['new-rule-1'],
+      }, {
+        ruleId: 'deprecated-rule-2',
+        replacedBy: ['new-rule-2'],
+      }],
+      warningCount: 0,
+    }]
+
+    const commonResult = {
+      messageTheme: expect.any(Function),
+      positionTheme: expect.any(Function),
+      ruleTheme: expect.any(Function),
+    }
+
+    lintFilesMock.mockImplementationOnce(() => lintResults)
+
+    expect(await eslintLib.lintFiles(testFiles)).toStrictEqual({
+      results: {
+        'index.ts': [{
+          ...commonResult,
+          position: '1:1',
+          message: 'Normal rule error',
+          rule: 'normal-error',
+          severity: 'X',
+        }, {
+          ...commonResult,
+          position: '2:1',
+          message: 'Normal rule warning',
+          rule: 'normal-warning',
+          severity: '!',
+        }, {
+          ...commonResult,
+          position: '3:1',
+          message: 'Error with trailing whitespace',
+          rule: 'spaced-error',
+          severity: 'X',
+        }],
+        'utils.ts': [{
+          ...commonResult,
+          position: '1:1',
+          message: 'Test core error',
+          rule: 'core-error',
+          severity: 'X',
+        }],
+      },
+      summary: {
+        deprecatedRules: ['deprecated-rule-1', 'deprecated-rule-2'],
+        errorCount: 5,
+        fileCount: 3,
+        fixableErrorCount: 3,
+        fixableWarningCount: 1,
+        linter: 'ESLint',
+        warningCount: 2,
+      },
+    })
+  })
+})

--- a/src/linters/__tests__/eslint.spec.ts
+++ b/src/linters/__tests__/eslint.spec.ts
@@ -178,10 +178,10 @@ describe('eslint', () => {
         }],
         'utils.ts': [{
           ...commonResult,
-          position: '1:1',
+          position: '0',
           message: 'Test core error',
           rule: 'core-error',
-          severity: 'X',
+          severity: '!',
         }],
       },
       summary: {

--- a/src/linters/eslint.ts
+++ b/src/linters/eslint.ts
@@ -13,21 +13,21 @@ const lintFiles = async (files: Array<string>): Promise<LintReport> => {
       fix: false,
     })
 
-    const results: Array<ESLint.LintResult> = await eslint.lintFiles(files)
+    const lintResults: Array<ESLint.LintResult> = await eslint.lintFiles(files)
 
     const reportResults: ReportResults = {}
 
     const reportSummary: ReportSummary = {
       deprecatedRules: [],
       errorCount: 0,
-      fileCount: results.length,
+      fileCount: lintResults.length,
       fixableErrorCount: 0,
       fixableWarningCount: 0,
       linter: Linter.ESLint,
       warningCount: 0,
     }
 
-    results.forEach(({ errorCount, filePath, fixableErrorCount, fixableWarningCount, messages, usedDeprecatedRules, warningCount }) => {
+    lintResults.forEach(({ errorCount, filePath, fixableErrorCount, fixableWarningCount, messages, usedDeprecatedRules, warningCount }) => {
       const file = filePath.replace(`${process.cwd()}/`, '')
 
       reportSummary.deprecatedRules = [...new Set([...reportSummary.deprecatedRules, ...usedDeprecatedRules.map(({ ruleId }) => ruleId)])]
@@ -57,7 +57,6 @@ const lintFiles = async (files: Array<string>): Promise<LintReport> => {
     }
   } catch (error: any) {
     colourLog.error('An error occurred while running eslint', error)
-    console.log()
     process.exit(1)
   }
 }

--- a/src/linters/eslint.ts
+++ b/src/linters/eslint.ts
@@ -42,7 +42,7 @@ const lintFiles = async (files: Array<string>): Promise<LintReport> => {
         }
 
         reportResults[file].push(formatResult({
-          column,
+          column: line ? column : undefined,
           lineNumber: line || 0,
           message: message.trim(),
           rule: ruleId || 'core-error',

--- a/src/linters/markdownlint/__tests__/index.spec.ts
+++ b/src/linters/markdownlint/__tests__/index.spec.ts
@@ -29,7 +29,7 @@ describe('markdownlint', () => {
     await markdownlintLib.lintFiles(testFiles)
 
     expect(loadConfig).toHaveBeenCalledTimes(1)
-    expect(colourLog.configDebug).toHaveBeenCalledWith('Using default markdownlint config:', mockedConfig)
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using default markdownlint config:', mockedConfig)
   })
 
   it('calls markdownlint with the config and files', async () => {

--- a/src/linters/markdownlint/__tests__/index.spec.ts
+++ b/src/linters/markdownlint/__tests__/index.spec.ts
@@ -3,7 +3,7 @@ import markdownlint from 'markdownlint'
 import colourLog from '@Utils/colourLog'
 
 import loadConfig from '../loadConfig'
-import markdownLib from '..'
+import markdownlintLib from '..'
 
 jest.mock('markdownlint')
 jest.mock('@Utils/colourLog')
@@ -26,7 +26,7 @@ describe('markdownlint', () => {
       callback(null, {})
     })
 
-    await markdownLib.lintFiles(testFiles)
+    await markdownlintLib.lintFiles(testFiles)
 
     expect(loadConfig).toHaveBeenCalledTimes(1)
     expect(colourLog.configDebug).toHaveBeenCalledWith('Using default markdownlint config:', mockedConfig)
@@ -37,7 +37,7 @@ describe('markdownlint', () => {
       callback(null, {})
     })
 
-    await markdownLib.lintFiles(testFiles)
+    await markdownlintLib.lintFiles(testFiles)
 
     expect(markdownlint).toHaveBeenCalledOnceWith({
       config: mockedConfig,
@@ -52,7 +52,7 @@ describe('markdownlint', () => {
       callback(error, undefined)
     })
 
-    await expect(markdownLib.lintFiles(testFiles)).rejects.toThrow(error)
+    await expect(markdownlintLib.lintFiles(testFiles)).rejects.toThrow(error)
 
     expect(colourLog.error).toHaveBeenCalledOnceWith('An error occurred while running markdownlint', error)
   })
@@ -62,7 +62,7 @@ describe('markdownlint', () => {
       callback(null, undefined)
     })
 
-    await expect(markdownLib.lintFiles(testFiles)).rejects.toThrow('No results')
+    await expect(markdownlintLib.lintFiles(testFiles)).rejects.toThrow('No results')
 
     expect(colourLog.error).toHaveBeenCalledOnceWith('An error occurred while running markdownlint: no results')
   })
@@ -74,7 +74,7 @@ describe('markdownlint', () => {
       })
     })
 
-    expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
+    expect(await markdownlintLib.lintFiles(testFiles)).toStrictEqual({
       results: {},
       summary: {
         deprecatedRules: [],
@@ -149,7 +149,7 @@ describe('markdownlint', () => {
       callback(null, markdownlintResult)
     })
 
-    expect(await markdownLib.lintFiles(testFiles)).toStrictEqual({
+    expect(await markdownlintLib.lintFiles(testFiles)).toStrictEqual({
       results: {
         'CHANGELOG.md': [{
           ...commonResult,

--- a/src/linters/markdownlint/__tests__/loadConfig.spec.ts
+++ b/src/linters/markdownlint/__tests__/loadConfig.spec.ts
@@ -12,7 +12,6 @@ describe('loadConfig', () => {
 
   jest.spyOn(colourLog, 'error').mockImplementation(() => {})
   jest.spyOn(markdownlint, 'readConfigSync').mockImplementation(() => ({ default: true }))
-  jest.spyOn(process, 'exit').mockImplementation(() => null as never)
 
   it('returns the custom config if it exists', () => {
     jest.mocked(fs.existsSync).mockReturnValueOnce(true)
@@ -46,16 +45,20 @@ describe('loadConfig', () => {
   })
 
   it('catches and logs any errors', () => {
+    expect.assertions(2)
+
     const error = new Error('Test error')
 
     jest.mocked(fs.existsSync).mockImplementationOnce(() => {
       throw error
     })
 
-    loadConfig()
-
-    expect(colourLog.error).toHaveBeenCalledWith('An error occurred while loading the markdownlint config', error)
-    expect(process.exit).toHaveBeenCalledWith(1)
+    try {
+      loadConfig()
+    } catch {
+      expect(colourLog.error).toHaveBeenCalledWith('An error occurred while loading the markdownlint config', error)
+      expect(process.exit).toHaveBeenCalledWith(1)
+    }
   })
 
 })

--- a/src/linters/markdownlint/index.ts
+++ b/src/linters/markdownlint/index.ts
@@ -72,8 +72,8 @@ const lintFiles = (files: Array<string>): Promise<LintReport> => new Promise((re
   })
 })
 
-const markdownLib = {
+const markdownlintLib = {
   lintFiles,
 }
 
-export default markdownLib
+export default markdownlintLib

--- a/src/linters/markdownlint/index.ts
+++ b/src/linters/markdownlint/index.ts
@@ -16,15 +16,10 @@ const lintFiles = (files: Array<string>): Promise<LintReport> => new Promise((re
   markdownlint({
     config,
     files,
-  }, (error: any, results: LintResults | undefined) => {
+  }, (error: any, lintResults: LintResults | undefined = {}) => {
     if (error) {
       colourLog.error('An error occurred while running markdownlint', error)
-      return reject(error)
-    }
-
-    if (!results) {
-      colourLog.error('An error occurred while running markdownlint: no results')
-      return reject(new Error('No results'))
+      process.exit(1)
     }
 
     const reportResults: ReportResults = {}
@@ -32,14 +27,14 @@ const lintFiles = (files: Array<string>): Promise<LintReport> => new Promise((re
     const reportSummary: ReportSummary = {
       deprecatedRules: [],
       errorCount: 0,
-      fileCount: Object.keys(results).length,
+      fileCount: Object.keys(lintResults).length,
       fixableErrorCount: 0,
       fixableWarningCount: 0,
       linter: Linter.Markdownlint,
       warningCount: 0,
     }
 
-    Object.entries(results).forEach(([file, errors]) => {
+    Object.entries(lintResults).forEach(([file, errors]) => {
       if (!errors.length) {
         return
       }

--- a/src/sourceFiles.ts
+++ b/src/sourceFiles.ts
@@ -6,7 +6,7 @@ import { pluralise } from '@Utils/transform'
 
 interface SourceFiles {
   filePattern: string
-  ignore: string
+  ignore: Array<string> | string
   linter: Linter
 }
 

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -93,29 +93,37 @@ describe('colourLog', () => {
     it('logs the text in red', () => {
       colourLog.error('An error occurred')
 
-      expect(chalk.red).toHaveBeenCalledOnceWith('An error occurred')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\nAn error occurred')
+      expect(chalk.red).toHaveBeenCalledOnceWith('\nAn error occurred.')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\nAn error occurred.')
     })
 
-    it('logs the text in red but does not log the error if global.debug is false', () => {
+    it('logs additional debug information if there is an error', () => {
+      colourLog.error('An error occurred', error)
+
+      expect(chalk.red).toHaveBeenCalledOnceWith('\nAn error occurred. Run with --debug for more information.')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\nAn error occurred. Run with --debug for more information.')
+    })
+
+    it('does not log the error if global.debug is false', () => {
       global.debug = false
 
       colourLog.error('An error occurred', error)
 
-      expect(chalk.red).toHaveBeenCalledOnceWith('An error occurred')
+      expect(chalk.red).toHaveBeenCalledOnceWith('\nAn error occurred. Run with --debug for more information.')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(1)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nAn error occurred')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nAn error occurred. Run with --debug for more information.')
     })
 
-    it('logs the text in red and logs the error if global.debug is true', () => {
+    it('logs the error if global.debug is true', () => {
       global.debug = true
 
       colourLog.error('An error occurred', error)
 
-      expect(chalk.red).toHaveBeenCalledOnceWith('An error occurred')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nAn error occurred')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, error)
+      expect(chalk.red).toHaveBeenCalledOnceWith('\nAn error occurred. Run with --debug for more information.')
+      expect(mockedConsoleLog).toHaveBeenCalledTimes(3)
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nAn error occurred. Run with --debug for more information.')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2)
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, error)
     })
 
   })

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -97,7 +97,7 @@ describe('colourLog', () => {
       expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\nAn error occurred.')
     })
 
-    it('logs additional debug information if there is an error', () => {
+    it('logs additional debug information if there is an error and global.debug is false', () => {
       colourLog.error('An error occurred', error)
 
       expect(chalk.red).toHaveBeenCalledOnceWith('\nAn error occurred. Run with --debug for more information.')
@@ -119,9 +119,9 @@ describe('colourLog', () => {
 
       colourLog.error('An error occurred', error)
 
-      expect(chalk.red).toHaveBeenCalledOnceWith('\nAn error occurred. Run with --debug for more information.')
+      expect(chalk.red).toHaveBeenCalledOnceWith('\nAn error occurred.')
       expect(mockedConsoleLog).toHaveBeenCalledTimes(3)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nAn error occurred. Run with --debug for more information.')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nAn error occurred.')
       expect(mockedConsoleLog).toHaveBeenNthCalledWith(2)
       expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, error)
     })

--- a/src/utils/__tests__/colourLog.spec.ts
+++ b/src/utils/__tests__/colourLog.spec.ts
@@ -175,8 +175,8 @@ describe('colourLog', () => {
 
       // File 1
       expect(mockedConsoleLog).toHaveBeenNthCalledWith(2)
-      expect(chalk.underline).toHaveBeenNthCalledWith(1, `${process.cwd()}/CONTRIBUTING.md`)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, `_${process.cwd()}/CONTRIBUTING.md_`)
+      expect(chalk.underline).toHaveBeenNthCalledWith(1, 'CONTRIBUTING.md')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '_CONTRIBUTING.md_')
       expect(spaceLog).toHaveBeenNthCalledWith(1, {
         columnKeys: ['severity', 'position', 'message', 'rule'],
         spaceSize: 2,
@@ -184,8 +184,8 @@ describe('colourLog', () => {
 
       // File 2
       expect(mockedConsoleLog).toHaveBeenNthCalledWith(4)
-      expect(chalk.underline).toHaveBeenNthCalledWith(2, `${process.cwd()}/README.md`)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(5, `_${process.cwd()}/README.md_`)
+      expect(chalk.underline).toHaveBeenNthCalledWith(2, 'README.md')
+      expect(mockedConsoleLog).toHaveBeenNthCalledWith(5, '_README.md_')
       expect(spaceLog).toHaveBeenNthCalledWith(2, {
         columnKeys: ['severity', 'position', 'message', 'rule'],
         spaceSize: 2,

--- a/src/utils/__tests__/transform.spec.ts
+++ b/src/utils/__tests__/transform.spec.ts
@@ -23,18 +23,6 @@ describe('formatResult', () => {
     }))
   })
 
-  it('truncates the message when it exceeds 72 characters', () => {
-    const formattedResult = formatResult({
-      ...commonResult,
-      message: 'This is a very long error message. So long that it exceeds 72 characters.',
-    })
-
-    expect(formattedResult).toStrictEqual(expect.objectContaining({
-      message: 'This is a very long error message. So long that it exceeds 72 charact...',
-      messageTheme: chalk.white,
-    }))
-  })
-
   it('formats the result with a position: line number and column number', () => {
     const formattedResult = formatResult(commonResult)
 

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -44,7 +44,7 @@ const colourLog = {
 
     Object.entries(results).forEach(([file, formattedResults]) => {
       console.log()
-      console.log(chalk.underline(`${process.cwd()}/${file}`))
+      console.log(chalk.underline(file))
       spaceLog({
         columnKeys: ['severity', 'position', 'message', 'rule'],
         spaceSize: 2,

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -22,9 +22,14 @@ const colourLog = {
   },
 
   error: (text: string, error?: Error | unknown) => {
-    console.log(`\n${chalk.red(text)}`)
-    if (error && global.debug === true) {
-      console.log(error)
+    if (error) {
+      console.log(chalk.red(`\n${text}. Run with --debug for more information.`))
+      if (global.debug === true) {
+        console.log()
+        console.log(error)
+      }
+    } else {
+      console.log(chalk.red(`\n${text}.`))
     }
   },
 

--- a/src/utils/colourLog.ts
+++ b/src/utils/colourLog.ts
@@ -22,14 +22,15 @@ const colourLog = {
   },
 
   error: (text: string, error?: Error | unknown) => {
-    if (error) {
-      console.log(chalk.red(`\n${text}. Run with --debug for more information.`))
-      if (global.debug === true) {
-        console.log()
-        console.log(error)
-      }
-    } else {
-      console.log(chalk.red(`\n${text}.`))
+    let errorMessage = `\n${text}.`
+    if (error && global.debug === false) {
+      errorMessage += ' Run with --debug for more information.'
+    }
+
+    console.log(chalk.red(errorMessage))
+    if (error && global.debug === true) {
+      console.log()
+      console.log(error)
     }
   },
 

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -12,7 +12,7 @@ interface Result {
 }
 
 const formatResult = ({ column, lineNumber, message, rule, severity }: Result): FormattedResult => ({
-  message: message.length > 72 ? `${message.substring(0, 69)}...` : message,
+  message,
   messageTheme: chalk.white,
   position: column ? `${lineNumber}:${column}` : lineNumber.toString(),
   positionTheme: chalk.dim,


### PR DESCRIPTION
## Details

### What have you changed?

- Process the lint results from `eslint` and log them in the console.

### Why are you making these changes?

- So that users can review the errors from `eslint`.
