### PR TITLE
Configured include and ignore directories and patterns 🚦

### DIFF
--- a/src/__tests__/filePatterns.spec.ts
+++ b/src/__tests__/filePatterns.spec.ts
@@ -1,0 +1,144 @@
+import colourLog from '@Utils/colourLog'
+import { Linter } from '@Types'
+
+import getFilePatterns from '../filePatterns'
+
+describe('filePatterns', () => {
+
+  jest.spyOn(colourLog, 'config').mockImplementation(() => {})
+  jest.spyOn(console, 'log').mockImplementation(() => {})
+
+  it('returns the correct file patterns for eslint', () => {
+    const filePatterns = getFilePatterns({})
+
+    const expectedPatterns = [
+      '**/*.{cjs,js,jsx,mjs,ts,tsx}',
+    ]
+
+    expect(filePatterns.includePatterns[Linter.ESLint]).toEqual(expectedPatterns)
+    expect(colourLog.config).toHaveBeenCalledWith('ESLint Patterns', expectedPatterns)
+  })
+
+  it('returns the correct file patterns for eslint with an additional include pattern', () => {
+    const filePatterns = getFilePatterns({
+      eslintInclude: 'foo'
+    })
+
+    const expectedPatterns = [
+      '**/*.{cjs,js,jsx,mjs,ts,tsx}',
+      'foo',
+    ]
+
+    expect(filePatterns.includePatterns[Linter.ESLint]).toEqual(expectedPatterns)
+    expect(colourLog.config).toHaveBeenCalledWith('ESLint Patterns', expectedPatterns)
+  })
+
+  it('returns the correct file patterns for eslint with several additional include patterns', () => {
+    const filePatterns = getFilePatterns({
+      eslintInclude: ['foo', 'bar'],
+    })
+
+    const expectedPatterns = [
+      '**/*.{cjs,js,jsx,mjs,ts,tsx}',
+      'foo',
+      'bar',
+    ]
+
+    expect(filePatterns.includePatterns[Linter.ESLint]).toEqual(expectedPatterns)
+    expect(colourLog.config).toHaveBeenCalledWith('ESLint Patterns', expectedPatterns)
+  })
+
+  it('returns the correct file patterns for markdownlint', () => {
+    const filePatterns = getFilePatterns({})
+
+    const expectedPatterns = [
+      '**/*.{md,mdx}',
+    ]
+
+    expect(filePatterns.includePatterns[Linter.Markdownlint]).toEqual(expectedPatterns)
+    expect(colourLog.config).toHaveBeenCalledWith('Markdownlint Patterns', expectedPatterns)
+  })
+
+  it('returns the correct file patterns for stylelint', () => {
+    const filePatterns = getFilePatterns({})
+
+    const expectedPatterns = [
+      '**/*.{css,scss,less,sass,styl,stylus}',
+    ]
+
+    expect(filePatterns.includePatterns[Linter.Stylelint]).toEqual(expectedPatterns)
+    expect(colourLog.config).toHaveBeenCalledWith('Stylelint Patterns', expectedPatterns)
+  })
+
+  it('returns the correct ignore file patterns', () => {
+    const filePatterns = getFilePatterns({})
+
+    const expectedPatterns = [
+      '**/+(coverage|dist|node_modules|tmp|tscOutput|vendor)/**',
+      '**/*.+(map|min).*',
+    ]
+
+    expect(filePatterns.ignorePatterns).toEqual(expectedPatterns)
+    expect(colourLog.config).toHaveBeenCalledWith('Ignore', expectedPatterns)
+  })
+
+  it('returns the correct ignore file patterns with an additional directory ignored', () => {
+    const filePatterns = getFilePatterns({
+      ignoreDirs: 'foo'
+    })
+
+    const expectedPatterns = [
+      '**/+(coverage|dist|foo|node_modules|tmp|tscOutput|vendor)/**',
+      '**/*.+(map|min).*',
+    ]
+
+    expect(filePatterns.ignorePatterns).toEqual(expectedPatterns)
+    expect(colourLog.config).toHaveBeenCalledWith('Ignore', expectedPatterns)
+  })
+
+  it('returns the correct ignore file patterns with several additional directories ignored', () => {
+    const filePatterns = getFilePatterns({
+      ignoreDirs: ['foo', 'bar'],
+    })
+
+    const expectedPatterns = [
+      '**/+(bar|coverage|dist|foo|node_modules|tmp|tscOutput|vendor)/**',
+      '**/*.+(map|min).*',
+    ]
+
+    expect(filePatterns.ignorePatterns).toEqual(expectedPatterns)
+    expect(colourLog.config).toHaveBeenCalledWith('Ignore', expectedPatterns)
+  })
+
+  it('returns the correct ignore file patterns with an additional pattern ignored', () => {
+    const filePatterns = getFilePatterns({
+      ignorePatterns: 'foo'
+    })
+
+    const expectedPatterns = [
+      '**/+(coverage|dist|node_modules|tmp|tscOutput|vendor)/**',
+      '**/*.+(map|min).*',
+      'foo',
+    ]
+
+    expect(filePatterns.ignorePatterns).toEqual(expectedPatterns)
+    expect(colourLog.config).toHaveBeenCalledWith('Ignore', expectedPatterns)
+  })
+
+  it('returns the correct ignore file patterns with several additional patterns ignored', () => {
+    const filePatterns = getFilePatterns({
+      ignorePatterns: ['foo', 'bar'],
+    })
+
+    const expectedPatterns = [
+      '**/+(coverage|dist|node_modules|tmp|tscOutput|vendor)/**',
+      '**/*.+(map|min).*',
+      'bar',
+      'foo',
+    ]
+
+    expect(filePatterns.ignorePatterns).toEqual(expectedPatterns)
+    expect(colourLog.config).toHaveBeenCalledWith('Ignore', expectedPatterns)
+  })
+
+})

--- a/src/filePatterns.ts
+++ b/src/filePatterns.ts
@@ -1,0 +1,56 @@
+import { type FilePatterns, Linter } from '@Types'
+import colourLog from '@Utils/colourLog'
+
+type StringOrArray = string | Array<string>
+
+interface GetFilePatterns {
+  eslintInclude?: StringOrArray
+  ignoreDirs?: StringOrArray
+  ignorePatterns?: StringOrArray
+}
+
+const enforceArray = (value: StringOrArray = []): Array<string> => Array.of(value).flat()
+
+const getFilePatterns = ({ eslintInclude, ignoreDirs, ignorePatterns }: GetFilePatterns): FilePatterns => {
+  const eslintIncludePatterns = [
+    '**/*.{cjs,js,jsx,mjs,ts,tsx}',
+    ...enforceArray(eslintInclude),
+  ]
+
+  const ignoreDirectories = [
+    'coverage',
+    'dist',
+    'node_modules',
+    'tmp',
+    'tscOutput',
+    'vendor',
+    ...enforceArray(ignoreDirs),
+  ].sort()
+
+  const ignoreGlobs = [
+    '**/*.+(map|min).*',
+    ...enforceArray(ignorePatterns),
+  ].sort()
+
+  const filePatterns = {
+    includePatterns: {
+      [Linter.ESLint]: eslintIncludePatterns,
+      [Linter.Markdownlint]: ['**/*.{md,mdx}'],
+      [Linter.Stylelint]: ['**/*.{css,scss,less,sass,styl,stylus}'],
+    },
+    ignorePatterns: [
+      `**/+(${ignoreDirectories.join('|')})/**`,
+      ...ignoreGlobs,
+    ],
+  }
+
+  colourLog.config('ESLint Patterns', filePatterns.includePatterns[Linter.ESLint])
+  colourLog.config('Markdownlint Patterns', filePatterns.includePatterns[Linter.Markdownlint])
+  colourLog.config('Stylelint Patterns', filePatterns.includePatterns[Linter.Stylelint])
+  colourLog.config('Ignore', filePatterns.ignorePatterns)
+  console.log()
+
+  return filePatterns
+}
+
+export default getFilePatterns

--- a/src/sourceFiles.ts
+++ b/src/sourceFiles.ts
@@ -5,8 +5,8 @@ import colourLog from '@Utils/colourLog'
 import { pluralise } from '@Utils/transform'
 
 interface SourceFiles {
-  filePattern: string
-  ignore: Array<string> | string
+  filePattern: Array<string>
+  ignore: Array<string>
   linter: Linter
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,12 +54,21 @@ interface LintReport {
  * LINT PILOT
  */
 
+interface FilePatterns {
+  includePatterns: {
+    [key in Linter]: Array<string>
+  }
+  ignorePatterns: Array<string>
+}
+
 interface RunLinter {
-  filePattern: string
+  filePattern: Array<string>
+  ignore: Array<string>
   linter: Linter
 }
 
 interface RunLintPilot {
+  filePatterns: FilePatterns
   title: string
   watch: boolean
 }
@@ -69,6 +78,7 @@ interface RunLintPilot {
  */
 
 export type {
+  FilePatterns,
   FormattedResult,
   LintReport,
   ReportResults,


### PR DESCRIPTION
## Details

### What have you changed?

- Added three new CLI options;
    - `--ignore-dirs`: To ignore directories from being linted (e.g. `vendor`).
    - `--ignore-patterns`: To ignore patterns from being linted (e.g. `**/*.example.js`).
    - `--eslint-include`: To include additional patterns when running ESLint (e.g. `**/*.vue`)

### Why are you making these changes?

- Users of Lint Pilot will likely need to ignore or include files different to those defined by default. Although using config files such as `.eslintignore` can help, in some use-cases configuring the options via the CLI may be preferable (for example, when ignoring a directory from all three linters to avoid duplication of effort).
