### PR TITLE
Added CLI option to enable and clear the cache 🧣

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ lib/
 node_modules
 
 # tests
+.lintpilotcache/
 coverage/
 
 # logs

--- a/jest-config/setup.ts
+++ b/jest-config/setup.ts
@@ -32,8 +32,11 @@ expect.extend({
       isCalledWithExpected = expected.every((arg, index) => this.equals(received.mock.calls[0][index], arg))
     }
 
+    const printExpected = this.utils.printExpected(expected)
+    const printReceived = this.utils.printReceived(received.mock.calls[0])
+
     return {
-      message: () => `expected ${received.getMockName()} to have been called exactly once with "${expected}" but received "${received.mock.calls[0]}"`,
+      message: () => `expected ${received.getMockName()} to have been called exactly once with arguments. Expected:\n\n${printExpected}\n\nReceived:\n\n${printReceived}\n`,
       pass: isCalledOnce && isCalledWithExpected,
     }
   },

--- a/src/linters/__tests__/eslint.spec.ts
+++ b/src/linters/__tests__/eslint.spec.ts
@@ -32,12 +32,30 @@ describe('eslint', () => {
     lintFilesMock.mockImplementationOnce(() => [])
 
     await eslintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: false
     })
 
     expect(ESLint).toHaveBeenCalledOnceWith({
       cache: false,
+      cacheLocation: undefined,
+      fix: false,
+    })
+  })
+
+  it('creates a new ESLint instance with cacheing enabled', async () => {
+    lintFilesMock.mockImplementationOnce(() => [])
+
+    await eslintLib.lintFiles({
+      cache: true,
+      files: testFiles,
+      fix: false
+    })
+
+    expect(ESLint).toHaveBeenCalledOnceWith({
+      cache: true,
+      cacheLocation: expect.stringContaining('.lintpilotcache/.eslintcache'),
       fix: false,
     })
   })
@@ -46,6 +64,7 @@ describe('eslint', () => {
     lintFilesMock.mockImplementationOnce(() => [])
 
     await eslintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: false
     })
@@ -64,6 +83,7 @@ describe('eslint', () => {
 
     try {
       await eslintLib.lintFiles({
+        cache: false,
         files: testFiles,
         fix: false
       })
@@ -79,6 +99,7 @@ describe('eslint', () => {
     lintFilesMock.mockImplementationOnce(() => lintResults)
 
     expect(await eslintLib.lintFiles({
+      cache: false,
       files: [],
       fix: false
     })).toStrictEqual({
@@ -99,6 +120,7 @@ describe('eslint', () => {
     lintFilesMock.mockImplementationOnce(() => noErrorLintResults)
 
     expect(await eslintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: false
     })).toStrictEqual({
@@ -204,6 +226,7 @@ describe('eslint', () => {
     lintFilesMock.mockImplementationOnce(() => lintResults)
 
     expect(await eslintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: false
     })).toStrictEqual({
@@ -263,6 +286,7 @@ describe('eslint', () => {
     lintFilesMock.mockImplementationOnce(() => noErrorLintResults)
 
     await eslintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: false
     })
@@ -278,6 +302,7 @@ describe('eslint', () => {
     lintFilesMock.mockImplementationOnce(() => noErrorLintResults)
 
     await eslintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: true
     })

--- a/src/linters/__tests__/stylelint.spec.ts
+++ b/src/linters/__tests__/stylelint.spec.ts
@@ -32,19 +32,49 @@ describe('stylelint', () => {
     }))
 
     await stylelintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: false,
     })
 
-    expect(stylelint.lint).toHaveBeenCalledOnceWith(expect.objectContaining({
+    expect(stylelint.lint).toHaveBeenCalledOnceWith({
       allowEmptyInput: true,
+      cache: false,
+      cacheLocation: undefined,
+      config: expect.anything(),
       files: testFiles,
       fix: false,
       quietDeprecationWarnings: true,
       reportDescriptionlessDisables: true,
       reportInvalidScopeDisables: true,
       reportNeedlessDisables: true,
+    })
+  })
+
+  it('calls stylelint.lint with cacheing enabled', async () => {
+    lintFilesMock.mockImplementationOnce(() => ({
+      results: [],
+      ruleMetadata: {},
     }))
+
+    await stylelintLib.lintFiles({
+      cache: true,
+      files: testFiles,
+      fix: false,
+    })
+
+    expect(stylelint.lint).toHaveBeenCalledOnceWith({
+      allowEmptyInput: true,
+      cache: true,
+      cacheLocation: expect.stringContaining('.lintpilotcache/.stylelintcache'),
+      config: expect.anything(),
+      files: testFiles,
+      fix: false,
+      quietDeprecationWarnings: true,
+      reportDescriptionlessDisables: true,
+      reportInvalidScopeDisables: true,
+      reportNeedlessDisables: true,
+    })
   })
 
   it('exists the process when stylelint throws an error', async () => {
@@ -58,6 +88,7 @@ describe('stylelint', () => {
 
     try {
       await stylelintLib.lintFiles({
+        cache: false,
         files: testFiles,
         fix: false,
       })
@@ -76,6 +107,7 @@ describe('stylelint', () => {
     }))
 
     expect(await stylelintLib.lintFiles({
+      cache: false,
       files: [],
       fix: false,
     })).toStrictEqual({
@@ -99,6 +131,7 @@ describe('stylelint', () => {
     }))
 
     expect(await stylelintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: false,
     })).toStrictEqual({
@@ -203,6 +236,7 @@ describe('stylelint', () => {
     }))
 
     expect(await stylelintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: false,
     })).toStrictEqual({
@@ -260,6 +294,7 @@ describe('stylelint', () => {
     }))
 
     await stylelintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: false,
     })
@@ -277,6 +312,7 @@ describe('stylelint', () => {
     }))
 
     await stylelintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: true,
     })

--- a/src/linters/eslint.ts
+++ b/src/linters/eslint.ts
@@ -1,15 +1,17 @@
 import { ESLint } from 'eslint'
 
 import { Linter, RuleSeverity } from '@Types'
+import { getCacheDirectory } from '@Utils/cache'
 import colourLog from '@Utils/colourLog'
 import { formatResult } from '@Utils/transform'
 
 import type { LintFiles, LintReport, ReportResults, ReportSummary } from '@Types'
 
-const lintFiles = async ({ files, fix }: LintFiles): Promise<LintReport> => {
+const lintFiles = async ({ cache, files, fix }: LintFiles): Promise<LintReport> => {
   try {
     const eslint = new ESLint({
-      cache: false,
+      cache,
+      cacheLocation: cache ? getCacheDirectory('.eslintcache') : undefined,
       fix,
     })
 

--- a/src/linters/markdownlint/__tests__/index.spec.ts
+++ b/src/linters/markdownlint/__tests__/index.spec.ts
@@ -28,6 +28,7 @@ describe('markdownlint', () => {
     jest.mocked(markdownlintAsync).mockResolvedValueOnce({})
 
     await markdownlintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: false,
     })
@@ -40,6 +41,7 @@ describe('markdownlint', () => {
     jest.mocked(markdownlintAsync).mockResolvedValueOnce({})
 
     await markdownlintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: false,
     })
@@ -61,6 +63,7 @@ describe('markdownlint', () => {
 
     try {
       await markdownlintLib.lintFiles({
+        cache: false,
         files: testFiles,
         fix: false,
       })
@@ -78,6 +81,7 @@ describe('markdownlint', () => {
     jest.mocked(markdownlintAsync).mockResolvedValueOnce(lintResults)
 
     await markdownlintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: false,
     })
@@ -97,6 +101,7 @@ describe('markdownlint', () => {
     jest.mocked(markdownlintAsync).mockResolvedValueOnce(lintResults)
 
     await markdownlintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: true,
     })
@@ -121,6 +126,7 @@ describe('markdownlint', () => {
       .mockResolvedValueOnce(lintResultsWithoutError)
 
     await markdownlintLib.lintFiles({
+      cache: false,
       files: testFiles,
       fix: true,
     })

--- a/src/linters/stylelint.ts
+++ b/src/linters/stylelint.ts
@@ -1,12 +1,13 @@
 import stylelint from 'stylelint'
 
 import { Linter, RuleSeverity } from '@Types'
+import { getCacheDirectory } from '@Utils/cache'
 import colourLog from '@Utils/colourLog'
 import { formatResult } from '@Utils/transform'
 
 import type { LintFiles, LintReport, ReportResults, ReportSummary } from '@Types'
 
-const lintFiles = async ({ files, fix }: LintFiles): Promise<LintReport> => {
+const lintFiles = async ({ cache, files, fix }: LintFiles): Promise<LintReport> => {
   try {
     // TODO: Stylelint config, extensible?
     const {
@@ -14,7 +15,8 @@ const lintFiles = async ({ files, fix }: LintFiles): Promise<LintReport> => {
       ruleMetadata,
     } = await stylelint.lint({
       allowEmptyInput: true,
-      cache: false,
+      cache,
+      cacheLocation: cache ? getCacheDirectory('.stylelintcache') : undefined,
       config: {
         rules: {
           'declaration-block-no-duplicate-properties': true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,11 +62,13 @@ interface FilePatterns {
 }
 
 interface LintFiles {
+  cache: boolean
   files: Array<string>
   fix: boolean
 }
 
 interface RunLinter {
+  cache: boolean
   filePattern: Array<string>
   fix: boolean
   ignore: Array<string>
@@ -74,6 +76,7 @@ interface RunLinter {
 }
 
 interface RunLintPilot {
+  cache: boolean
   filePatterns: FilePatterns
   fix: boolean
   title: string

--- a/src/utils/__tests__/cache.spec.ts
+++ b/src/utils/__tests__/cache.spec.ts
@@ -1,0 +1,53 @@
+import fs from 'fs'
+import path from 'path'
+
+import colourLog from '@Utils/colourLog'
+
+import { clearCacheDirectory, getCacheDirectory } from '../cache'
+
+jest.mock('fs')
+jest.mock('@Utils/colourLog', () => ({
+  info: jest.fn(),
+}))
+
+describe('clearCacheDirectory', () => {
+
+  const expectedCacheDirectory = `${process.cwd()}/.lintpilotcache`
+
+  it('clears the cache directory if it exists', () => {
+    jest.mocked(fs.existsSync).mockReturnValueOnce(true)
+
+    clearCacheDirectory()
+
+    expect(fs.existsSync).toHaveBeenCalledWith(expectedCacheDirectory)
+    expect(fs.rmSync).toHaveBeenCalledWith(expectedCacheDirectory, {
+      force: true,
+      recursive: true,
+    })
+    expect(colourLog.info).toHaveBeenCalledWith('Cache cleared.\n')
+  })
+
+  it('does not attempt to clear the cache if the directory does not exist', () => {
+    jest.mocked(fs.existsSync).mockReturnValueOnce(false)
+
+    clearCacheDirectory()
+
+    expect(fs.existsSync).toHaveBeenCalledWith(expectedCacheDirectory)
+    expect(fs.rmSync).not.toHaveBeenCalled()
+    expect(colourLog.info).toHaveBeenCalledWith('No cache to clear.\n')
+  })
+
+})
+
+describe('getCacheDirectory', () => {
+
+  it('returns the correct cache directory path for a given file', () => {
+    jest.spyOn(path, 'resolve')
+
+    const result = getCacheDirectory('.eslintcache')
+
+    expect(path.resolve).toHaveBeenCalledWith(process.cwd(), '.lintpilotcache', '.eslintcache')
+    expect(result).toEqual(`${process.cwd()}/.lintpilotcache/.eslintcache`)
+  })
+
+})

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,27 @@
+import fs from 'fs'
+import path from 'path'
+
+import colourLog from './colourLog'
+
+const CACHE_FOLDER = '.lintpilotcache'
+
+const clearCacheDirectory = () => {
+  const cacheDirectory = path.resolve(process.cwd(), CACHE_FOLDER)
+
+  if (fs.existsSync(cacheDirectory)) {
+    fs.rmSync(cacheDirectory, {
+      force: true,
+      recursive: true,
+    })
+    colourLog.info('Cache cleared.\n')
+  } else {
+    colourLog.info('No cache to clear.\n')
+  }
+}
+
+const getCacheDirectory = (file: string) => path.resolve(process.cwd(), CACHE_FOLDER, file)
+
+export {
+  clearCacheDirectory,
+  getCacheDirectory,
+}


### PR DESCRIPTION
## Details

### What have you changed?

- Added new CLI options; one to enable cacheing and another to clear the cache.

### Why are you making these changes?

- Both eslint and stylelint support a cache which can be used to only lint files which have changed. This can speed up the linting process which is important when lint tasks are run in pre-commit hooks.

    Having an option to clear the cache is also important. Although users could just delete the cache files, doing so via the CLI is easy and acts as a reminder that linting with the cache enabled may have different results than running in a deployment pipeline where no cache is available.
