### PR TITLE
Refactor file watching and ensure graceful watcher cleanup 🧼

### DIFF
--- a/src/__tests__/exit-handler.spec.ts
+++ b/src/__tests__/exit-handler.spec.ts
@@ -6,20 +6,26 @@ jest.mock('@Utils/colour-log')
 
 describe('exitHandler', () => {
 
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => true)
+  })
+
   it('exits with an exit code of 0', () => {
     try {
-      exitHandler(0, 'Normal Exit')
+      exitHandler(0, 'Normal Exit', undefined)
     } catch {
       expect(colourLog.error).not.toHaveBeenCalled()
+      expect(console.log).toHaveBeenCalledOnceWith()
       expect(process.exit).toHaveBeenCalledWith(0)
     }
   })
 
   it('exits with an exit code of 1', () => {
     try {
-      exitHandler(1, 'Error Exit')
+      exitHandler(1, 'Error Exit', undefined)
     } catch {
       expect(colourLog.error).not.toHaveBeenCalled()
+      expect(console.log).toHaveBeenCalledOnceWith()
       expect(process.exit).toHaveBeenCalledWith(1)
     }
   })
@@ -28,10 +34,23 @@ describe('exitHandler', () => {
     const err = new Error('Test Error')
 
     try {
-      exitHandler(1, 'Error Exit', err)
+      exitHandler(1, 'Error Exit', undefined, err)
     } catch {
       expect(colourLog.error).toHaveBeenCalledOnceWith('Error Exit', err)
+      expect(console.log).toHaveBeenCalledOnceWith()
       expect(process.exit).toHaveBeenCalledWith(1)
+    }
+  })
+
+  it('closes the watcher if provided', () => {
+    const mockWatcher = { close: jest.fn() }
+
+    try {
+      exitHandler(0, 'Normal Exit', mockWatcher as any)
+    } catch {
+      expect(mockWatcher.close).toHaveBeenCalled()
+      expect(console.log).toHaveBeenCalledOnceWith()
+      expect(process.exit).toHaveBeenCalledWith(0)
     }
   })
 

--- a/src/exit-handler.ts
+++ b/src/exit-handler.ts
@@ -1,12 +1,24 @@
 import colourLog from '@Utils/colour-log'
 
+import type { FSWatcher } from 'chokidar'
+
 type ExitCode = 0 | 1
 
-const exitHandler = (exitCode: ExitCode, reason: string, error?: Error | string | unknown) => {
+const exitHandler = (
+  exitCode: ExitCode,
+  reason: string,
+  watcher: FSWatcher | undefined,
+  error?: Error | string | unknown
+) => {
   if (exitCode === 1 && error) {
     colourLog.error(reason, error)
   }
 
+  if (watcher) {
+    watcher.close()
+  }
+
+  console.log()
   process.exit(exitCode)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,17 @@
 import { exitHandler } from './exit-handler'
 import { createProgram } from './program'
 
-process.on('exit', () => console.log())
-process.on('SIGINT', () => exitHandler(0, 'SIGINT'))
-process.on('SIGTERM', () => exitHandler(0, 'SIGTERM'))
-process.on('uncaughtException', error => exitHandler(1, 'Unexpected Error', error))
-process.on('unhandledRejection', error => exitHandler(1, 'Unhandled Promise', error))
+import type { FSWatcher } from 'chokidar'
 
-const program = createProgram()
+let watcher: FSWatcher | undefined
+
+process.on('SIGINT', () => exitHandler(0, 'SIGINT', watcher))
+process.on('SIGTERM', () => exitHandler(0, 'SIGTERM', watcher))
+process.on('uncaughtException', error => exitHandler(1, 'Unexpected Error', watcher, error))
+process.on('unhandledRejection', error => exitHandler(1, 'Unhandled Promise', watcher, error))
+
+const program = createProgram({
+  setWatcher: (w: FSWatcher) => { watcher = w }
+})
 
 program.parseAsync(process.argv)

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander'
 
-import { Events, Linter } from '@Types'
+import { Linter } from '@Types/lint'
 import { clearCacheDirectory } from '@Utils/cache'
 import colourLog from '@Utils/colour-log'
 import { notifyResults } from '@Utils/notifier'
@@ -9,7 +9,7 @@ import { clearTerminal } from '@Utils/terminal'
 import type { LintReport, RunLinter, RunLintPilot } from '@Types'
 import { getFilePatterns } from '@Utils/file-patterns'
 import sourceFiles from '@Utils/source-files'
-import { fileWatcherEvents, watchFiles } from '@Utils/watch-files'
+import { EVENTS, fileWatcherEvents, watchFiles } from '@Utils/watch-files'
 
 import linters from './linters/index'
 
@@ -138,7 +138,7 @@ const createProgram = (): Command => {
           ignorePatterns: filePatterns.ignorePatterns,
         })
 
-        fileWatcherEvents.on(Events.FILE_CHANGED, ({ message }) => {
+        fileWatcherEvents.on(EVENTS.FILE_CHANGED, ({ message }) => {
           clearTerminal()
           colourLog.info(message)
           console.log()

--- a/src/program.ts
+++ b/src/program.ts
@@ -13,6 +13,8 @@ import { EVENTS, fileWatcherEvents, watchFiles } from '@Utils/watch-files'
 
 import linters from './linters/index'
 
+import type { FileChangedEventPayload } from '@Utils/watch-files'
+
 const runLinter = async ({ cache, eslintUseLegacyConfig, filePattern, fix, linter, ignore }: RunLinter) => {
   const startTime = new Date().getTime()
   colourLog.info(`Running ${linter.toLowerCase()}...`)
@@ -135,7 +137,7 @@ const createProgram = (): Command => {
       if (watch) {
         watchFiles(filePatterns)
 
-        fileWatcherEvents.on(EVENTS.FILE_CHANGED, ({ message }) => {
+        fileWatcherEvents.on(EVENTS.FILE_CHANGED, ({ message }: FileChangedEventPayload) => {
           clearTerminal()
           colourLog.info(message)
           console.log()

--- a/src/program.ts
+++ b/src/program.ts
@@ -9,7 +9,7 @@ import { clearTerminal } from '@Utils/terminal'
 import type { LintReport, RunLinter, RunLintPilot } from '@Types'
 import { getFilePatterns } from '@Utils/file-patterns'
 import sourceFiles from '@Utils/source-files'
-import { fileChangeEvent, watchFiles } from '@Utils/watch-files'
+import { fileWatcherEvents, watchFiles } from '@Utils/watch-files'
 
 import linters from './linters/index'
 
@@ -138,7 +138,7 @@ const createProgram = (): Command => {
           ignorePatterns: filePatterns.ignorePatterns,
         })
 
-        fileChangeEvent.on(Events.FILE_CHANGED, ({ message }) => {
+        fileWatcherEvents.on(Events.FILE_CHANGED, ({ message }) => {
           clearTerminal()
           colourLog.info(message)
           console.log()

--- a/src/program.ts
+++ b/src/program.ts
@@ -133,10 +133,7 @@ const createProgram = (): Command => {
       runLintPilot(lintPilotOptions)
 
       if (watch) {
-        watchFiles({
-          filePatterns: Object.values(filePatterns.includePatterns).flat(),
-          ignorePatterns: filePatterns.ignorePatterns,
-        })
+        watchFiles(filePatterns)
 
         fileWatcherEvents.on(EVENTS.FILE_CHANGED, ({ message }) => {
           clearTerminal()

--- a/src/program.ts
+++ b/src/program.ts
@@ -13,7 +13,12 @@ import { EVENTS, fileWatcherEvents, watchFiles } from '@Utils/watch-files'
 
 import linters from './linters/index'
 
+import type { FSWatcher } from 'chokidar'
 import type { FileChangedEventPayload } from '@Utils/watch-files'
+
+interface CreateProgramOptions {
+  setWatcher: (watcher: FSWatcher) => void
+}
 
 const runLinter = async ({ cache, eslintUseLegacyConfig, filePattern, fix, linter, ignore }: RunLinter) => {
   const startTime = new Date().getTime()
@@ -80,7 +85,7 @@ const runLintPilot = ({ cache, eslintUseLegacyConfig, filePatterns, fix, title, 
   })
 }
 
-const createProgram = (): Command => {
+const createProgram = ({ setWatcher }: CreateProgramOptions): Command => {
   const program = new Command()
 
   program
@@ -135,7 +140,8 @@ const createProgram = (): Command => {
       runLintPilot(lintPilotOptions)
 
       if (watch) {
-        watchFiles(filePatterns)
+        const watcher = watchFiles(filePatterns)
+        setWatcher(watcher)
 
         fileWatcherEvents.on(EVENTS.FILE_CHANGED, ({ message }: FileChangedEventPayload) => {
           clearTerminal()

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,10 +2,6 @@
  * ENUMS
  */
 
-enum Events {
-  FILE_CHANGED = 'FILE_CHANGED',
-}
-
 enum Linter {
   ESLint = 'ESLint',
   Markdownlint = 'Markdownlint',
@@ -103,7 +99,6 @@ export type {
 }
 
 export {
-  Events,
   Linter,
   RuleSeverity,
 }

--- a/src/utils/__tests__/watch-files.spec.ts
+++ b/src/utils/__tests__/watch-files.spec.ts
@@ -4,7 +4,7 @@ import chokidar from 'chokidar'
 
 import { Events } from '@Types'
 
-import { fileChangeEvent, watchFiles } from '../watch-files'
+import { fileWatcherEvents, watchFiles } from '../watch-files'
 
 jest.mock('node:fs')
 jest.mock('chokidar')
@@ -37,7 +37,7 @@ describe('watchFiles', () => {
   })
 
   afterEach(() => {
-    fileChangeEvent.removeAllListeners()
+    fileWatcherEvents.removeAllListeners()
   })
 
   it('initialises chokidar with the correct file and ignore patterns', () => {
@@ -58,7 +58,7 @@ describe('watchFiles', () => {
 
     const mockPath = 'mock/existing-file.ts'
 
-    fileChangeEvent.on(Events.FILE_CHANGED, params => {
+    fileWatcherEvents.on(Events.FILE_CHANGED, params => {
       expect(params).toStrictEqual({
         message: `File \`${mockPath}\` has been changed.`,
         path: mockPath,
@@ -76,7 +76,7 @@ describe('watchFiles', () => {
 
     const mockPath = 'mock/update-file.ts'
 
-    fileChangeEvent.on(Events.FILE_CHANGED, params => {
+    fileWatcherEvents.on(Events.FILE_CHANGED, params => {
       expect(params).toStrictEqual({
         message: `File \`${mockPath}\` has been changed.`,
         path: mockPath,
@@ -98,7 +98,7 @@ describe('watchFiles', () => {
 
     const mockPath = 'mock/unchanged-file.ts'
 
-    fileChangeEvent.on(Events.FILE_CHANGED, params => {
+    fileWatcherEvents.on(Events.FILE_CHANGED, params => {
       expect(params).toStrictEqual({
         message: `File \`${mockPath}\` has been changed.`,
         path: mockPath,
@@ -121,7 +121,7 @@ describe('watchFiles', () => {
 
     const mockPath = 'mock/new-file.ts'
 
-    fileChangeEvent.on(Events.FILE_CHANGED, params => {
+    fileWatcherEvents.on(Events.FILE_CHANGED, params => {
       expect(params).toStrictEqual({
         message: `File \`${mockPath}\` has been added.`,
         path: mockPath,
@@ -139,7 +139,7 @@ describe('watchFiles', () => {
 
     const mockPath = 'mock/legacy-file.ts'
 
-    fileChangeEvent.on(Events.FILE_CHANGED, params => {
+    fileWatcherEvents.on(Events.FILE_CHANGED, params => {
       expect(params).toStrictEqual({
         message: `File \`${mockPath}\` has been removed.`,
         path: mockPath,

--- a/src/utils/__tests__/watch-files.spec.ts
+++ b/src/utils/__tests__/watch-files.spec.ts
@@ -55,6 +55,15 @@ describe('watchFiles', () => {
     fileWatcherEvents.removeAllListeners()
   })
 
+  it('returns the watcher instance', () => {
+    const watcher = watchFiles({
+      includePatterns: getIncludePatterns(),
+      ignorePatterns: [],
+    })
+
+    expect(watcher).toBe(mockWatcher)
+  })
+
   it('initialises chokidar for all linters when no specific linters are provided', () => {
     watchFiles({
       includePatterns: getIncludePatterns(),

--- a/src/utils/__tests__/watch-files.spec.ts
+++ b/src/utils/__tests__/watch-files.spec.ts
@@ -14,6 +14,13 @@ jest.mock('chokidar')
 describe('watchFiles', () => {
   let mockWatcher: chokidar.FSWatcher
 
+  const getEventPromise = (eventHandler: jest.Mock): Promise<void> => new Promise<void>(resolve => {
+    fileWatcherEvents.on(EVENTS.FILE_CHANGED, (params: Record<string, unknown>) => {
+      eventHandler(params)
+      resolve()
+    })
+  })
+
   const getIncludePatterns = (esPattern: string = '**/*.ts'): FilePatterns['includePatterns'] => ({
     [Linter.ESLint]: [esPattern],
     [Linter.Markdownlint]: ['**/*.md'],
@@ -78,118 +85,121 @@ describe('watchFiles', () => {
     })
   })
 
-  it('emits a "FILE_CHANGED" event when saving an existing file (because there is no hash map yet)', done => {
-    expect.assertions(1)
-
-    const mockPath = 'mock/existing-file.ts'
-
-    fileWatcherEvents.on(EVENTS.FILE_CHANGED, params => {
-      expect(params).toStrictEqual({
-        message: `File \`${mockPath}\` has been changed.`,
-        path: mockPath,
-      })
-      done()
-    })
-
-    watchFiles({
-      includePatterns: getIncludePatterns(mockPath),
-      ignorePatterns: [],
-    })
-
-    saveFile(mockPath, 'hello-world', 'change')
-  })
-
-  it('emits a "FILE_CHANGED" event when saving a file if the file content changes', done => {
+  it('emits a "FILE_CHANGED" event when saving an existing file (because there is no hash map yet)', async () => {
     expect.assertions(2)
 
-    const mockPath = 'mock/update-file.ts'
-
-    fileWatcherEvents.on(EVENTS.FILE_CHANGED, params => {
-      expect(params).toStrictEqual({
-        message: `File \`${mockPath}\` has been changed.`,
-        path: mockPath,
-      })
-    })
+    const eventHandler = jest.fn()
+    const eventPromise = getEventPromise(eventHandler)
+    const mockPath = 'mock/existing-file.ts'
 
     watchFiles({
       includePatterns: getIncludePatterns(mockPath),
       ignorePatterns: [],
     })
+    saveFile(mockPath, 'hello-world', 'change')
 
+    await eventPromise
+
+    expect(eventHandler).toHaveBeenCalledTimes(1)
+    expect(eventHandler).toHaveBeenNthCalledWith(1, {
+      message: `File \`${mockPath}\` has been changed.`,
+      path: mockPath,
+    })
+  })
+
+  it('emits a "FILE_CHANGED" event when saving a file if the file content changes', async () => {
+    expect.assertions(3)
+
+    const eventHandler = jest.fn()
+    const eventPromise = getEventPromise(eventHandler)
+    const mockPath = 'mock/update-file.ts'
+
+    watchFiles({
+      includePatterns: getIncludePatterns(mockPath),
+      ignorePatterns: [],
+    })
     saveFile(mockPath, 'old-content', 'change') // First save - no hash map yet
     saveFile(mockPath, 'new-content', 'change') // Second save - content hash is different
 
-    setTimeout(() => {
-      done()
-    }, 100)
+    await eventPromise
+
+    expect(eventHandler).toHaveBeenCalledTimes(2)
+    expect(eventHandler).toHaveBeenNthCalledWith(1, {
+      message: `File \`${mockPath}\` has been changed.`,
+      path: mockPath,
+    })
+    expect(eventHandler).toHaveBeenNthCalledWith(2, {
+      message: `File \`${mockPath}\` has been changed.`,
+      path: mockPath,
+    })
   })
 
-  it('does not emit a "FILE_CHANGED" event when saving a file if the file content did not change', done => {
-    expect.assertions(1)
+  it('does not emit a "FILE_CHANGED" event when saving a file if the file content did not change', async () => {
+    expect.assertions(2)
 
+    const eventHandler = jest.fn()
+    const eventPromise = getEventPromise(eventHandler)
     const mockPath = 'mock/unchanged-file.ts'
-
-    fileWatcherEvents.on(EVENTS.FILE_CHANGED, params => {
-      expect(params).toStrictEqual({
-        message: `File \`${mockPath}\` has been changed.`,
-        path: mockPath,
-      })
-    })
 
     watchFiles({
       includePatterns: getIncludePatterns(mockPath),
       ignorePatterns: [],
     })
-
     saveFile(mockPath, 'old-content', 'change') // First save - no hash map yet
     saveFile(mockPath, 'old-content', 'change') // Second save - content hash is the same
     saveFile(mockPath, 'old-content', 'change') // Third save - content hash is still the same
 
-    setTimeout(() => {
-      done()
-    }, 100)
+    await eventPromise
+
+    expect(eventHandler).toHaveBeenCalledTimes(1)
+    expect(eventHandler).toHaveBeenNthCalledWith(1, {
+      message: `File \`${mockPath}\` has been changed.`,
+      path: mockPath,
+    })
   })
 
-  it('emits a "FILE_CHANGED" event when a new file is added', done => {
-    expect.assertions(1)
+  it('emits a "FILE_CHANGED" event when a new file is added', async () => {
+    expect.assertions(2)
 
+    const eventHandler = jest.fn()
+    const eventPromise = getEventPromise(eventHandler)
     const mockPath = 'mock/new-file.ts'
 
-    fileWatcherEvents.on(EVENTS.FILE_CHANGED, params => {
-      expect(params).toStrictEqual({
-        message: `File \`${mockPath}\` has been added.`,
-        path: mockPath,
-      })
-      done()
-    })
-
     watchFiles({
       includePatterns: getIncludePatterns(mockPath),
       ignorePatterns: [],
     })
-
     saveFile(mockPath, 'new-content', 'add')
+
+    await eventPromise
+
+    expect(eventHandler).toHaveBeenCalledTimes(1)
+    expect(eventHandler).toHaveBeenNthCalledWith(1, {
+      message: `File \`${mockPath}\` has been added.`,
+      path: mockPath,
+    })
   })
 
-  it('emits a "FILE_CHANGED" event when a file is removed', done => {
-    expect.assertions(1)
+  it('emits a "FILE_CHANGED" event when a file is removed', async () => {
+    expect.assertions(2)
 
+    const eventHandler = jest.fn()
+    const eventPromise = getEventPromise(eventHandler)
     const mockPath = 'mock/legacy-file.ts'
-
-    fileWatcherEvents.on(EVENTS.FILE_CHANGED, params => {
-      expect(params).toStrictEqual({
-        message: `File \`${mockPath}\` has been removed.`,
-        path: mockPath,
-      })
-      done()
-    })
 
     watchFiles({
       includePatterns: getIncludePatterns(mockPath),
       ignorePatterns: [],
     })
-
     saveFile(mockPath, 'legacy-content', 'unlink')
+
+    await eventPromise
+
+    expect(eventHandler).toHaveBeenCalledTimes(1)
+    expect(eventHandler).toHaveBeenNthCalledWith(1, {
+      message: `File \`${mockPath}\` has been removed.`,
+      path: mockPath,
+    })
   })
 
 })

--- a/src/utils/__tests__/watch-files.spec.ts
+++ b/src/utils/__tests__/watch-files.spec.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'fs'
+import { readFile } from 'node:fs'
 
 import chokidar from 'chokidar'
 
@@ -6,7 +6,7 @@ import { Events } from '@Types'
 
 import { fileChangeEvent, watchFiles } from '../watch-files'
 
-jest.mock('fs')
+jest.mock('node:fs')
 jest.mock('chokidar')
 
 describe('watchFiles', () => {

--- a/src/utils/__tests__/watch-files.spec.ts
+++ b/src/utils/__tests__/watch-files.spec.ts
@@ -2,9 +2,7 @@ import { readFile } from 'node:fs'
 
 import chokidar from 'chokidar'
 
-import { Events } from '@Types'
-
-import { fileWatcherEvents, watchFiles } from '../watch-files'
+import { EVENTS, fileWatcherEvents, watchFiles } from '../watch-files'
 
 jest.mock('node:fs')
 jest.mock('chokidar')
@@ -58,7 +56,7 @@ describe('watchFiles', () => {
 
     const mockPath = 'mock/existing-file.ts'
 
-    fileWatcherEvents.on(Events.FILE_CHANGED, params => {
+    fileWatcherEvents.on(EVENTS.FILE_CHANGED, params => {
       expect(params).toStrictEqual({
         message: `File \`${mockPath}\` has been changed.`,
         path: mockPath,
@@ -76,7 +74,7 @@ describe('watchFiles', () => {
 
     const mockPath = 'mock/update-file.ts'
 
-    fileWatcherEvents.on(Events.FILE_CHANGED, params => {
+    fileWatcherEvents.on(EVENTS.FILE_CHANGED, params => {
       expect(params).toStrictEqual({
         message: `File \`${mockPath}\` has been changed.`,
         path: mockPath,
@@ -98,7 +96,7 @@ describe('watchFiles', () => {
 
     const mockPath = 'mock/unchanged-file.ts'
 
-    fileWatcherEvents.on(Events.FILE_CHANGED, params => {
+    fileWatcherEvents.on(EVENTS.FILE_CHANGED, params => {
       expect(params).toStrictEqual({
         message: `File \`${mockPath}\` has been changed.`,
         path: mockPath,
@@ -121,7 +119,7 @@ describe('watchFiles', () => {
 
     const mockPath = 'mock/new-file.ts'
 
-    fileWatcherEvents.on(Events.FILE_CHANGED, params => {
+    fileWatcherEvents.on(EVENTS.FILE_CHANGED, params => {
       expect(params).toStrictEqual({
         message: `File \`${mockPath}\` has been added.`,
         path: mockPath,
@@ -139,7 +137,7 @@ describe('watchFiles', () => {
 
     const mockPath = 'mock/legacy-file.ts'
 
-    fileWatcherEvents.on(Events.FILE_CHANGED, params => {
+    fileWatcherEvents.on(EVENTS.FILE_CHANGED, params => {
       expect(params).toStrictEqual({
         message: `File \`${mockPath}\` has been removed.`,
         path: mockPath,

--- a/src/utils/watch-files.ts
+++ b/src/utils/watch-files.ts
@@ -4,21 +4,22 @@ import { readFile } from 'node:fs'
 
 import chokidar from 'chokidar'
 
+import type { FilePatterns, Linter } from '@Types/lint'
+
 enum EVENTS {
   FILE_CHANGED = 'FILE_CHANGED',
-}
-
-interface WatchFiles {
-  filePatterns: Array<string>
-  ignorePatterns: Array<string>
 }
 
 const fileWatcherEvents = new EventEmitter()
 
 const fileHashes = new Map<string, string>()
 
-const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
-  const watcher = chokidar.watch(filePatterns, {
+const watchFiles = ({ includePatterns, ignorePatterns }: FilePatterns, linters?: Array<Linter>) => {
+  const filteredPatterns = linters
+    ? linters.flatMap(linter => includePatterns[linter])
+    : Object.values(includePatterns).flat()
+
+  const watcher = chokidar.watch(filteredPatterns, {
     ignored: ignorePatterns,
     ignoreInitial: true,
     persistent: true,

--- a/src/utils/watch-files.ts
+++ b/src/utils/watch-files.ts
@@ -10,6 +10,11 @@ enum EVENTS {
   FILE_CHANGED = 'FILE_CHANGED',
 }
 
+interface FileChangedEventPayload {
+  message: string
+  path: string
+}
+
 const fileWatcherEvents = new EventEmitter()
 
 const fileHashes = new Map<string, string>()
@@ -29,7 +34,7 @@ const watchFiles = ({ includePatterns, ignorePatterns }: FilePatterns, linters?:
     fileWatcherEvents.emit(EVENTS.FILE_CHANGED, {
       message: `File \`${path}\` has been added.`,
       path,
-    })
+    } satisfies FileChangedEventPayload)
   })
 
   watcher.on('change', (path, _stats) => {
@@ -44,7 +49,7 @@ const watchFiles = ({ includePatterns, ignorePatterns }: FilePatterns, linters?:
         fileWatcherEvents.emit(EVENTS.FILE_CHANGED, {
           message: `File \`${path}\` has been changed.`,
           path,
-        })
+        } satisfies FileChangedEventPayload)
       }
     })
   })
@@ -53,8 +58,12 @@ const watchFiles = ({ includePatterns, ignorePatterns }: FilePatterns, linters?:
     fileWatcherEvents.emit(EVENTS.FILE_CHANGED, {
       message: `File \`${path}\` has been removed.`,
       path,
-    })
+    } satisfies FileChangedEventPayload)
   })
+}
+
+export type {
+  FileChangedEventPayload,
 }
 
 export {

--- a/src/utils/watch-files.ts
+++ b/src/utils/watch-files.ts
@@ -61,6 +61,8 @@ const watchFiles = ({ includePatterns, ignorePatterns }: FilePatterns, linters?:
       path,
     } satisfies FileChangedEventPayload)
   })
+
+  return watcher
 }
 
 export type {

--- a/src/utils/watch-files.ts
+++ b/src/utils/watch-files.ts
@@ -1,6 +1,6 @@
-import { createHash } from 'crypto'
-import { EventEmitter } from 'events'
-import { readFile } from 'fs'
+import { createHash } from 'node:crypto'
+import { EventEmitter } from 'node:events'
+import { readFile } from 'node:fs'
 
 import chokidar from 'chokidar'
 

--- a/src/utils/watch-files.ts
+++ b/src/utils/watch-files.ts
@@ -4,7 +4,9 @@ import { readFile } from 'node:fs'
 
 import chokidar from 'chokidar'
 
-import { Events } from '@Types'
+enum EVENTS {
+  FILE_CHANGED = 'FILE_CHANGED',
+}
 
 interface WatchFiles {
   filePatterns: Array<string>
@@ -23,7 +25,7 @@ const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
   })
 
   watcher.on('add', (path, _stats) => {
-    fileWatcherEvents.emit(Events.FILE_CHANGED, {
+    fileWatcherEvents.emit(EVENTS.FILE_CHANGED, {
       message: `File \`${path}\` has been added.`,
       path,
     })
@@ -34,7 +36,7 @@ const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
       const newHash = createHash('md5').update(data).digest('hex')
       if (fileHashes.get(path) !== newHash) {
         fileHashes.set(path, newHash)
-        fileWatcherEvents.emit(Events.FILE_CHANGED, {
+        fileWatcherEvents.emit(EVENTS.FILE_CHANGED, {
           message: `File \`${path}\` has been changed.`,
           path,
         })
@@ -43,7 +45,7 @@ const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
   })
 
   watcher.on('unlink', path => {
-    fileWatcherEvents.emit(Events.FILE_CHANGED, {
+    fileWatcherEvents.emit(EVENTS.FILE_CHANGED, {
       message: `File \`${path}\` has been removed.`,
       path,
     })
@@ -51,6 +53,7 @@ const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
 }
 
 export {
+  EVENTS,
   fileWatcherEvents,
   watchFiles,
 }

--- a/src/utils/watch-files.ts
+++ b/src/utils/watch-files.ts
@@ -33,7 +33,11 @@ const watchFiles = ({ includePatterns, ignorePatterns }: FilePatterns, linters?:
   })
 
   watcher.on('change', (path, _stats) => {
-    readFile(path, 'utf8', (_error, data) => {
+    readFile(path, 'utf8', (error, data) => {
+      /* istanbul ignore next */
+      if (error) {
+        return
+      }
       const newHash = createHash('md5').update(data).digest('hex')
       if (fileHashes.get(path) !== newHash) {
         fileHashes.set(path, newHash)

--- a/src/utils/watch-files.ts
+++ b/src/utils/watch-files.ts
@@ -55,6 +55,7 @@ const watchFiles = ({ includePatterns, ignorePatterns }: FilePatterns, linters?:
   })
 
   watcher.on('unlink', path => {
+    fileHashes.delete(path)
     fileWatcherEvents.emit(EVENTS.FILE_CHANGED, {
       message: `File \`${path}\` has been removed.`,
       path,

--- a/src/utils/watch-files.ts
+++ b/src/utils/watch-files.ts
@@ -11,11 +11,9 @@ interface WatchFiles {
   ignorePatterns: Array<string>
 }
 
-const fileChangeEvent = new EventEmitter()
+const fileWatcherEvents = new EventEmitter()
 
 const fileHashes = new Map<string, string>()
-
-const getHash = (data: string) => createHash('md5').update(data).digest('hex')
 
 const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
   const watcher = chokidar.watch(filePatterns, {
@@ -25,7 +23,7 @@ const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
   })
 
   watcher.on('add', (path, _stats) => {
-    fileChangeEvent.emit(Events.FILE_CHANGED, {
+    fileWatcherEvents.emit(Events.FILE_CHANGED, {
       message: `File \`${path}\` has been added.`,
       path,
     })
@@ -33,10 +31,10 @@ const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
 
   watcher.on('change', (path, _stats) => {
     readFile(path, 'utf8', (_error, data) => {
-      const newHash = getHash(data)
+      const newHash = createHash('md5').update(data).digest('hex')
       if (fileHashes.get(path) !== newHash) {
         fileHashes.set(path, newHash)
-        fileChangeEvent.emit(Events.FILE_CHANGED, {
+        fileWatcherEvents.emit(Events.FILE_CHANGED, {
           message: `File \`${path}\` has been changed.`,
           path,
         })
@@ -45,7 +43,7 @@ const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
   })
 
   watcher.on('unlink', path => {
-    fileChangeEvent.emit(Events.FILE_CHANGED, {
+    fileWatcherEvents.emit(Events.FILE_CHANGED, {
       message: `File \`${path}\` has been removed.`,
       path,
     })
@@ -53,6 +51,6 @@ const watchFiles = ({ filePatterns, ignorePatterns }: WatchFiles) => {
 }
 
 export {
-  fileChangeEvent,
+  fileWatcherEvents,
   watchFiles,
 }


### PR DESCRIPTION
## Details

### What have you changed?

- ♻️ Refactored `watch-files` to support watching files for all or specific linters.

- 🧪 Improved unit tests for file watching, using async event assertions and robust mocking.

- 🚪 Gracefully close watcher on process exit via the centralised exit handler.

- 📝 Exported event payload types for type-safe event consumption.

### Why are you making these changes?

- ♻️ To enable reusability and flexibility for future CLI commands (e.g., running individual linters).

- 🧪 To ensure tests are reliable, maintainable, and accurately reflect event-driven behaviour.

- 🚪 To prevent resource leaks and ensure a smooth developer experience when exiting watch mode.

- 📝 To improve type safety.
