### PR TITLE
Updated cache directory 🏜️

### DIFF
--- a/src/__tests__/exit-handler.spec.ts
+++ b/src/__tests__/exit-handler.spec.ts
@@ -11,6 +11,8 @@ describe('exitHandler', () => {
   })
 
   it('exits with an exit code of 0', () => {
+    expect.assertions(3)
+
     try {
       exitHandler(0, 'Normal Exit', undefined)
     } catch {
@@ -21,6 +23,8 @@ describe('exitHandler', () => {
   })
 
   it('exits with an exit code of 1', () => {
+    expect.assertions(3)
+
     try {
       exitHandler(1, 'Error Exit', undefined)
     } catch {
@@ -31,6 +35,8 @@ describe('exitHandler', () => {
   })
 
   it('logs an error when the exit code is 1 and there is an error', () => {
+    expect.assertions(3)
+
     const err = new Error('Test Error')
 
     try {
@@ -43,6 +49,8 @@ describe('exitHandler', () => {
   })
 
   it('closes the watcher if provided', () => {
+    expect.assertions(3)
+
     const mockWatcher = { close: jest.fn() }
 
     try {

--- a/src/linters/__tests__/eslint.spec.ts
+++ b/src/linters/__tests__/eslint.spec.ts
@@ -79,7 +79,7 @@ describe('eslint', () => {
 
     expect(ESLint).toHaveBeenCalledOnceWith({
       cache: true,
-      cacheLocation: expect.stringContaining('.lintpilotcache/eslint'),
+      cacheLocation: expect.stringContaining('.cache/lint/eslint'),
       fix: false,
     })
   })

--- a/src/linters/__tests__/stylelint.spec.ts
+++ b/src/linters/__tests__/stylelint.spec.ts
@@ -76,7 +76,7 @@ describe('stylelint', () => {
     expect(stylelint.lint).toHaveBeenCalledOnceWith({
       allowEmptyInput: true,
       cache: true,
-      cacheLocation: expect.stringContaining('.lintpilotcache/stylelint'),
+      cacheLocation: expect.stringContaining('.cache/lint/stylelint'),
       config: expect.anything(),
       files: testFiles,
       fix: false,

--- a/src/utils/__tests__/cache.spec.ts
+++ b/src/utils/__tests__/cache.spec.ts
@@ -10,7 +10,7 @@ jest.mock('@Utils/colour-log')
 
 describe('clearCacheDirectory', () => {
 
-  const expectedCacheDirectory = `${process.cwd()}/.lintpilotcache`
+  const expectedCacheDirectory = `${process.cwd()}/.cache/lint`
 
   it('clears the cache directory if it exists', () => {
     jest.mocked(fs.existsSync).mockReturnValueOnce(true)
@@ -62,13 +62,13 @@ describe('clearCacheDirectory', () => {
 
 describe('getCacheDirectory', () => {
 
-  it('returns the resolved path to the cache sub-directory for a given tool', () => {
+  it('returns the resolved path to a cache sub-directory', () => {
     jest.spyOn(path, 'resolve')
 
     const result = getCacheDirectory('eslint')
 
-    expect(path.resolve).toHaveBeenCalledOnceWith(process.cwd(), '.lintpilotcache', 'eslint')
-    expect(result).toBe(`${process.cwd()}/.lintpilotcache/eslint`)
+    expect(path.resolve).toHaveBeenCalledOnceWith(process.cwd(), '.cache/lint', 'eslint')
+    expect(result).toBe(`${process.cwd()}/.cache/lint/eslint`)
   })
 
 })

--- a/src/utils/__tests__/file-patterns.spec.ts
+++ b/src/utils/__tests__/file-patterns.spec.ts
@@ -43,8 +43,8 @@ describe('getFilePatterns', () => {
 
     const expectedPatterns = [
       '**/*.{cjs,js,jsx,mjs,ts,tsx}',
-      'foo',
       'bar',
+      'foo',
     ]
 
     expect(filePatterns.includePatterns[Linter.ESLint]).toStrictEqual(expectedPatterns)
@@ -152,6 +152,7 @@ describe('getFilePatterns', () => {
     expect(colourLog.config).toHaveBeenCalledWith('Markdownlint Patterns', expect.any(Array))
     expect(colourLog.config).toHaveBeenCalledWith('Stylelint Patterns', expect.any(Array))
     expect(colourLog.config).toHaveBeenCalledWith('Ignore', expect.any(Array))
+    expect(console.log).toHaveBeenCalledOnceWith()
   })
 
   test.each([
@@ -164,6 +165,7 @@ describe('getFilePatterns', () => {
     expect(colourLog.config).toHaveBeenCalledTimes(2)
     expect(colourLog.config).toHaveBeenNthCalledWith(1, patternName, expect.any(Array))
     expect(colourLog.config).toHaveBeenNthCalledWith(2, 'Ignore', expect.any(Array))
+    expect(console.log).toHaveBeenCalledOnceWith()
   })
 
 })

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -5,7 +5,7 @@ import colourLog from '@Utils/colour-log'
 
 type CacheSubDirectory = 'eslint' | 'stylelint'
 
-const CACHE_DIRECTORY = '.lintpilotcache'
+const CACHE_DIRECTORY = '.cache/lint'
 
 const clearCacheDirectory = (subDir?: CacheSubDirectory) => {
   const cacheDirectory = path.resolve(process.cwd(), CACHE_DIRECTORY, subDir || '')

--- a/src/utils/file-patterns.ts
+++ b/src/utils/file-patterns.ts
@@ -11,7 +11,7 @@ type GetFilePatternsOptions = Pick<LintCommandOptions, 'eslintInclude' | 'ignore
 const getFilePatterns = ({ eslintInclude = [], ignoreDirs = [], ignorePatterns = [], linters }: GetFilePatternsOptions): FilePatterns => {
   const eslintIncludePatterns = [
     '**/*.{cjs,js,jsx,mjs,ts,tsx}',
-    ...Array.of(eslintInclude).flat(),
+    ...Array.of(eslintInclude).flat().sort(),
   ]
 
   const ignoreDirectories = [


### PR DESCRIPTION
## Details

### What have you changed?

- Store the cache in `.cache/lint/${linter}/`.

### Why are you making these changes?

- Better developer experience;
  - Simplified configuration: one path to set and remember.
  - Easier cleanup: Developers (or CI scripts) can `rm -rf .cache/lint/` instead of knowing `.eslintcache` and `.stylelintcache`.
  - Better portability: Easier to exclude from version control or Docker containers.
  - Consistency with other tools: Many modern tools (like Prettier, Jest, and Vite) use `.cache/` or similar folders to group build/test/lint caches.
  - The `.cache` folder is more likely to exist in `.gitignore` files.