### PR TITLE
Use package.json for CLI name, description, and version in Commander 🔖

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@babel/core": "7.25.2",
     "@babel/preset-env": "7.25.4",
     "@babel/preset-typescript": "7.24.7",
+    "@rollup/plugin-json": "6.1.0",
     "@rollup/plugin-node-resolve": "15.2.3",
     "@rollup/plugin-typescript": "11.1.6",
     "@types/eslint": "9.6.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
+import json from '@rollup/plugin-json'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import typescript from '@rollup/plugin-typescript'
 import copy from 'rollup-plugin-copy'
@@ -37,6 +38,7 @@ export default [{
     format: 'es',
   },
   plugins: [
+    json(),
     nodeResolve({
       preferBuiltins: true,
     }),

--- a/src/program.ts
+++ b/src/program.ts
@@ -11,6 +11,7 @@ import { getFilePatterns } from '@Utils/file-patterns'
 import sourceFiles from '@Utils/source-files'
 import { EVENTS, fileWatcherEvents, watchFiles } from '@Utils/watch-files'
 
+import { description, name, version } from '../package.json'
 import linters from './linters/index'
 
 import type { FSWatcher } from 'chokidar'
@@ -82,9 +83,9 @@ const createProgram = ({ setWatcher }: CreateProgramOptions): Command => {
   const program = new Command()
 
   program
-    .name('lint-pilot')
-    .description('Your co-pilot for maintaining high code quality with seamless ESLint, Stylelint, and Markdownlint integration.')
-    .version('0.0.1')
+    .name(name)
+    .description(description)
+    .version(version)
     .addHelpText('beforeAll', '\n✈️ Lint Pilot ✈️\n')
     .showHelpAfterError('\n💡 Run `lint-pilot --help` for more information.\n')
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
       "@Types/*": ["./src/types/*"],
       "@Utils/*": ["./src/utils/*"],
     },
+    "resolveJsonModule": true,
     "rootDir": "./",
     "strict": true,
     "target": "ESNext"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2399,6 +2399,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-json@npm:6.1.0":
+  version: 6.1.0
+  resolution: "@rollup/plugin-json@npm:6.1.0"
+  dependencies:
+    "@rollup/pluginutils": "npm:^5.1.0"
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 10c0/9400c431b5e0cf3088ba2eb2d038809a2b0fb2a84ed004997da85582f48cd64958ed3168893c4f2c8109e38652400ed68282d0c92bf8ec07a3b2ef2e1ceab0b7
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-node-resolve@npm:15.2.3":
   version: 15.2.3
   resolution: "@rollup/plugin-node-resolve@npm:15.2.3"
@@ -5715,6 +5729,7 @@ __metadata:
     "@babel/core": "npm:7.25.2"
     "@babel/preset-env": "npm:7.25.4"
     "@babel/preset-typescript": "npm:7.24.7"
+    "@rollup/plugin-json": "npm:6.1.0"
     "@rollup/plugin-node-resolve": "npm:15.2.3"
     "@rollup/plugin-typescript": "npm:11.1.6"
     "@stylistic/stylelint-plugin": "npm:3.0.1"


### PR DESCRIPTION
## Details

### What have you changed?
<!-- List changes in past tense -->
- 🔖 Used values from `package.json` for the CLI name, description, and version in Commander.

### Why are you making these changes?
<!-- List reasons in past tense -->
- 🔖 Centralising metadata in `package.json` makes the CLI easier to maintain and reduces duplication.
- 🔧 This change lays the groundwork for automating releases in the future by ensuring versioning is consistent.
