### PR TITLE
Improved types, testing, ignore generated directory 🐢

### DIFF
--- a/src/__tests__/exit-handler.spec.ts
+++ b/src/__tests__/exit-handler.spec.ts
@@ -2,6 +2,8 @@ import colourLog from '@Utils/colour-log'
 
 import { exitHandler } from '../exit-handler'
 
+import type { FSWatcher } from 'chokidar'
+
 jest.mock('@Utils/colour-log')
 
 describe('exitHandler', () => {
@@ -18,7 +20,7 @@ describe('exitHandler', () => {
     } catch {
       expect(colourLog.error).not.toHaveBeenCalled()
       expect(console.log).toHaveBeenCalledOnceWith()
-      expect(process.exit).toHaveBeenCalledWith(0)
+      expect(process.exit).toHaveBeenCalledOnceWith(0)
     }
   })
 
@@ -30,7 +32,7 @@ describe('exitHandler', () => {
     } catch {
       expect(colourLog.error).not.toHaveBeenCalled()
       expect(console.log).toHaveBeenCalledOnceWith()
-      expect(process.exit).toHaveBeenCalledWith(1)
+      expect(process.exit).toHaveBeenCalledOnceWith(1)
     }
   })
 
@@ -44,7 +46,7 @@ describe('exitHandler', () => {
     } catch {
       expect(colourLog.error).toHaveBeenCalledOnceWith('Error Exit', err)
       expect(console.log).toHaveBeenCalledOnceWith()
-      expect(process.exit).toHaveBeenCalledWith(1)
+      expect(process.exit).toHaveBeenCalledOnceWith(1)
     }
   })
 
@@ -54,11 +56,11 @@ describe('exitHandler', () => {
     const mockWatcher = { close: jest.fn() }
 
     try {
-      exitHandler(0, 'Normal Exit', mockWatcher as any)
+      exitHandler(0, 'Normal Exit', mockWatcher as Partial<FSWatcher> as FSWatcher)
     } catch {
       expect(mockWatcher.close).toHaveBeenCalled()
       expect(console.log).toHaveBeenCalledOnceWith()
-      expect(process.exit).toHaveBeenCalledWith(0)
+      expect(process.exit).toHaveBeenCalledOnceWith(0)
     }
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ process.on('uncaughtException', error => exitHandler(1, 'Unexpected Error', watc
 process.on('unhandledRejection', error => exitHandler(1, 'Unhandled Promise', watcher, error))
 
 const program = createProgram({
-  setWatcher: (w: FSWatcher) => { watcher = w }
+  setWatcher: (w: FSWatcher) => watcher = w
 })
 
 program.parseAsync(process.argv)

--- a/src/types/lint.ts
+++ b/src/types/lint.ts
@@ -30,13 +30,13 @@ interface FilePatterns {
 
 interface FormattedResult {
   message: string
-  messageTheme: (input: string) => string
+  messageTheme: (message: string) => string
   position: string
-  positionTheme: (input: string) => string
+  positionTheme: (position: string) => string
   rule: string
-  ruleTheme: (input: string) => string
+  ruleTheme: (rule: string) => string
   severity: string
-  severityTheme: (input: string) => string
+  severityTheme: (severity: string) => string
 }
 
 interface ReportResults {

--- a/src/utils/__tests__/file-patterns.spec.ts
+++ b/src/utils/__tests__/file-patterns.spec.ts
@@ -77,7 +77,7 @@ describe('getFilePatterns', () => {
     const filePatterns = getFilePatterns({})
 
     const expectedPatterns = [
-      '**/+(coverage|dist|node_modules|tmp|tscOutput|vendor)/**',
+      '**/+(coverage|dist|generated|node_modules|tmp|tscOutput|vendor)/**',
       '**/*.+(map|min).*',
     ]
 
@@ -91,7 +91,7 @@ describe('getFilePatterns', () => {
     })
 
     const expectedPatterns = [
-      '**/+(coverage|dist|foo|node_modules|tmp|tscOutput|vendor)/**',
+      '**/+(coverage|dist|foo|generated|node_modules|tmp|tscOutput|vendor)/**',
       '**/*.+(map|min).*',
     ]
 
@@ -105,7 +105,7 @@ describe('getFilePatterns', () => {
     })
 
     const expectedPatterns = [
-      '**/+(bar|coverage|dist|foo|node_modules|tmp|tscOutput|vendor)/**',
+      '**/+(bar|coverage|dist|foo|generated|node_modules|tmp|tscOutput|vendor)/**',
       '**/*.+(map|min).*',
     ]
 
@@ -119,7 +119,7 @@ describe('getFilePatterns', () => {
     })
 
     const expectedPatterns = [
-      '**/+(coverage|dist|node_modules|tmp|tscOutput|vendor)/**',
+      '**/+(coverage|dist|generated|node_modules|tmp|tscOutput|vendor)/**',
       '**/*.+(map|min).*',
       'foo',
     ]
@@ -134,7 +134,7 @@ describe('getFilePatterns', () => {
     })
 
     const expectedPatterns = [
-      '**/+(coverage|dist|node_modules|tmp|tscOutput|vendor)/**',
+      '**/+(coverage|dist|generated|node_modules|tmp|tscOutput|vendor)/**',
       '**/*.+(map|min).*',
       'bar',
       'foo',

--- a/src/utils/__tests__/source-files.spec.ts
+++ b/src/utils/__tests__/source-files.spec.ts
@@ -8,6 +8,7 @@ import sourceFiles from '../source-files'
 import type { FilePatterns } from '@Types/lint'
 
 jest.mock('glob')
+jest.mock('@Utils/colour-log')
 
 describe('sourceFiles', () => {
 
@@ -20,20 +21,13 @@ describe('sourceFiles', () => {
     ignorePatterns: ['node_modules'],
   })
 
-  beforeEach(() => {
-    jest.spyOn(colourLog, 'configDebug').mockImplementation(() => {})
-    jest.spyOn(colourLog, 'error').mockImplementation(() => {})
-    jest.spyOn(colourLog, 'info').mockImplementation(() => {})
-    jest.spyOn(colourLog, 'warning').mockImplementation(() => {})
-  })
-
-  it('logs a warning and returns an empty array when no includePatterns are provided for the linter', async () => {
+  it('logs a warning and returns an empty array when no include patterns are provided for the linter', async () => {
     expect.assertions(3)
 
     const files = await sourceFiles(getFilePatterns([]), Linter.ESLint)
 
     expect(glob).not.toHaveBeenCalled()
-    expect(colourLog.warning).toHaveBeenCalledWith('\nNo file patterns provided for ESLint. Skipping.')
+    expect(colourLog.warning).toHaveBeenCalledOnceWith('\nNo file patterns provided for ESLint. Skipping.')
     expect(files).toStrictEqual([])
   })
 
@@ -48,7 +42,7 @@ describe('sourceFiles', () => {
 
     await sourceFiles(getFilePatterns(), linter)
 
-    expect(glob).toHaveBeenCalledWith(expectedFilePattern, { ignore: [ 'node_modules' ] })
+    expect(glob).toHaveBeenCalledOnceWith(expectedFilePattern, { ignore: [ 'node_modules' ] })
   })
 
   it('logs an info message and returns an empty array when no files are sourced for the linter', async () => {
@@ -58,8 +52,8 @@ describe('sourceFiles', () => {
 
     const files = await sourceFiles(getFilePatterns(), Linter.ESLint)
 
-    expect(glob).toHaveBeenCalledWith(['**/*.ts'], { ignore: [ 'node_modules' ] })
-    expect(colourLog.info).toHaveBeenCalledWith('\nNo files found for ESLint.')
+    expect(glob).toHaveBeenCalledOnceWith(['**/*.ts'], { ignore: [ 'node_modules' ] })
+    expect(colourLog.info).toHaveBeenCalledOnceWith('\nNo files found for ESLint.')
     expect(files).toStrictEqual([])
   })
 
@@ -72,9 +66,9 @@ describe('sourceFiles', () => {
 
     const files = await sourceFiles(getFilePatterns(), Linter.ESLint)
 
-    expect(glob).toHaveBeenCalledWith(['**/*.ts'], { ignore: [ 'node_modules' ] })
+    expect(glob).toHaveBeenCalledOnceWith(['**/*.ts'], { ignore: [ 'node_modules' ] })
     expect(files).toStrictEqual(mockedFiles)
-    expect(colourLog.configDebug).toHaveBeenCalledWith('Sourced 1 file for ESLint:', mockedFiles)
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Sourced 1 file for ESLint:', mockedFiles)
   })
 
   it('returns multiple files sourced for the file pattern - excluding any duplicates', async () => {
@@ -87,9 +81,9 @@ describe('sourceFiles', () => {
 
     const files = await sourceFiles(getFilePatterns(), Linter.ESLint)
 
-    expect(glob).toHaveBeenCalledWith(['**/*.ts'], { ignore: [ 'node_modules' ] })
+    expect(glob).toHaveBeenCalledOnceWith(['**/*.ts'], { ignore: [ 'node_modules' ] })
     expect(files).toStrictEqual(expectedFiles)
-    expect(colourLog.configDebug).toHaveBeenCalledWith('Sourced 2 files for ESLint:', expectedFiles)
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Sourced 2 files for ESLint:', expectedFiles)
   })
 
   it('catches any errors and exists the process', async () => {
@@ -102,8 +96,8 @@ describe('sourceFiles', () => {
     try {
       await sourceFiles(getFilePatterns(), Linter.ESLint)
     } catch {
-      expect(colourLog.error).toHaveBeenCalledWith('An error occurred while sourcing files for ESLint', error)
-      expect(process.exit).toHaveBeenCalledWith(1)
+      expect(colourLog.error).toHaveBeenCalledOnceWith('An error occurred while sourcing files for ESLint', error)
+      expect(process.exit).toHaveBeenCalledOnceWith(1)
     }
   })
 

--- a/src/utils/__tests__/terminal.spec.ts
+++ b/src/utils/__tests__/terminal.spec.ts
@@ -7,7 +7,7 @@ describe('clearTerminal', () => {
 
     clearTerminal()
 
-    expect(stdoutSpy).toHaveBeenCalledWith('\x1Bc\x1B[3J\x1B[2J\x1B[H')
+    expect(stdoutSpy).toHaveBeenCalledOnceWith('\x1Bc\x1B[3J\x1B[2J\x1B[H')
   })
 
 })

--- a/src/utils/__tests__/watch-files.spec.ts
+++ b/src/utils/__tests__/watch-files.spec.ts
@@ -6,13 +6,14 @@ import { Linter } from '@Types/lint'
 
 import { EVENTS, fileWatcherEvents, watchFiles } from '../watch-files'
 
+import type { FSWatcher } from 'chokidar'
 import type { FilePatterns } from '@Types/lint'
 
 jest.mock('node:fs')
 jest.mock('chokidar')
 
 describe('watchFiles', () => {
-  let mockWatcher: chokidar.FSWatcher
+  let mockWatcher: FSWatcher
 
   const getEventPromise = (eventHandler: jest.Mock): Promise<void> => new Promise<void>(resolve => {
     fileWatcherEvents.on(EVENTS.FILE_CHANGED, (params: Record<string, unknown>) => {
@@ -46,7 +47,7 @@ describe('watchFiles', () => {
       close: jest.fn(),
       on: jest.fn(),
       unwatch: jest.fn(),
-    } as unknown as chokidar.FSWatcher
+    } as Partial<FSWatcher> as FSWatcher
 
     jest.mocked(chokidar.watch).mockReturnValue(mockWatcher)
   })
@@ -70,7 +71,7 @@ describe('watchFiles', () => {
       ignorePatterns: ['node_modules'],
     })
 
-    expect(chokidar.watch).toHaveBeenCalledWith(['**/*.ts', '**/*.md', '**/*.css'], {
+    expect(chokidar.watch).toHaveBeenCalledOnceWith(['**/*.ts', '**/*.md', '**/*.css'], {
       ignored: ['node_modules'],
       ignoreInitial: true,
       persistent: true,
@@ -87,7 +88,7 @@ describe('watchFiles', () => {
       ignorePatterns: ['node_modules'],
     }, [linter])
 
-    expect(chokidar.watch).toHaveBeenCalledWith([expectedPattern], {
+    expect(chokidar.watch).toHaveBeenCalledOnceWith([expectedPattern], {
       ignored: ['node_modules'],
       ignoreInitial: true,
       persistent: true,

--- a/src/utils/file-patterns.ts
+++ b/src/utils/file-patterns.ts
@@ -17,6 +17,7 @@ const getFilePatterns = ({ eslintInclude = [], ignoreDirs = [], ignorePatterns =
   const ignoreDirectories = [
     'coverage',
     'dist',
+    'generated',
     'node_modules',
     'tmp',
     'tscOutput',

--- a/src/utils/notifier.ts
+++ b/src/utils/notifier.ts
@@ -11,7 +11,7 @@ const notifyResults = (reports: Array<LintReport>, title: string): ExitCode => {
   let totalErrorCount = reports.reduce((total, { summary: { errorCount } }) => total + errorCount, 0)
   if (totalErrorCount > 0) {
     notifier.notify({
-      message: `${totalErrorCount} ${pluralise('error', totalErrorCount)} found. Please fix ${totalErrorCount > 1 ? 'them ' : 'it '}before continuing.`,
+      message: `${totalErrorCount} ${pluralise('error', totalErrorCount)} found. Please fix ${totalErrorCount === 1 ? 'it ' : 'them '}before continuing.`,
       sound: 'Frog',
       title: `🚨 ${title}`,
     })
@@ -22,7 +22,7 @@ const notifyResults = (reports: Array<LintReport>, title: string): ExitCode => {
   let totalWarningCount = reports.reduce((total, { summary: { warningCount } }) => total + warningCount, 0)
   if (totalWarningCount > 0) {
     notifier.notify({
-      message: `${totalWarningCount} ${pluralise('warning', totalWarningCount)} found. Please review ${totalWarningCount > 1 ? 'them ' : ''}before continuing.`,
+      message: `${totalWarningCount} ${pluralise('warning', totalWarningCount)} found. Please review ${totalWarningCount === 1 ? '' : 'them '}before continuing.`,
       sound: 'Frog',
       title: `⚠️ ${title}`,
     })


### PR DESCRIPTION
## Details

### What have you changed?
<!-- List changes in past tense -->
- ✅ Improved test assertions by preferring `toHaveBeenCalledOnceWith` over `toHaveBeenCalledWith`.

- 🧾 Improved type safety by preferring `as Partial<Type> as Type` over `as any`.

- 🚫 Excluded the `generated` directory from linting.

### Why are you making these changes?
<!-- List reasons in past tense -->
- ✅ Using `toHaveBeenCalledOnceWith` provides stricter, more accurate test assertions and reduces false positives in test behaviour.

- 🧾 Replacing `as any` with `as Partial<Type> as Type` improves type safety and makes the intent clearer for future maintainers.

- 🚫 Generated files are machine-created and should not be linted, avoiding unnecessary noise and reducing CI time.
