### PR TITLE
Refine utility behaviour and streamline tests 🧙‍♂️

### DIFF
--- a/jest-config/setup.ts
+++ b/jest-config/setup.ts
@@ -2,6 +2,8 @@
  * MOCKS AND SPIES
  */
 
+jest.mock('@Utils/colour-log')
+
 jest.spyOn(process, 'exit').mockImplementation(code => {
   throw new Error(`process.exit(${code})`)
 })

--- a/jest-config/setup.ts
+++ b/jest-config/setup.ts
@@ -16,6 +16,10 @@ beforeEach(() => {
   global.debug = false
 })
 
+afterEach(() => {
+  jest.useRealTimers()
+})
+
 /*
  * EXTEND EXPECT
  */

--- a/jest-config/setup.ts
+++ b/jest-config/setup.ts
@@ -20,19 +20,15 @@ beforeEach(() => {
 
 expect.extend({
   toHaveBeenCalledOnceWith(received, ...expected) {
-    const isCalledOnce = received.mock.calls.length === 1
-    let isCalledWithExpected = false
-
-    if (isCalledOnce) {
-      isCalledWithExpected = expected.every((arg, index) => this.equals(received.mock.calls[0][index], arg))
-    }
+    const calls = received.mock.calls
+    const pass = calls.length === 1 && expected.every((arg, index) => this.equals(calls[0][index], arg))
 
     const printExpected = this.utils.printExpected(expected)
-    const printReceived = this.utils.printReceived(received.mock.calls[0])
+    const printReceived = this.utils.printReceived(calls)
 
     return {
-      message: () => `expected ${received.getMockName()} to have been called exactly once with arguments. Expected:\n\n${printExpected}\n\nReceived:\n\n${printReceived}\n`,
-      pass: isCalledOnce && isCalledWithExpected,
+      message: () => `expected ${received.getMockName()} to have been called once with arguments. Expected:\n\n${printExpected}\n\nReceived:\n\n${printReceived}\n`,
+      pass,
     }
   },
 })

--- a/src/__tests__/exit-handler.spec.ts
+++ b/src/__tests__/exit-handler.spec.ts
@@ -4,8 +4,6 @@ import { exitHandler } from '../exit-handler'
 
 import type { FSWatcher } from 'chokidar'
 
-jest.mock('@Utils/colour-log')
-
 describe('exitHandler', () => {
 
   it('exits with an exit code of 0', async () => {

--- a/src/__tests__/exit-handler.spec.ts
+++ b/src/__tests__/exit-handler.spec.ts
@@ -8,58 +8,50 @@ jest.mock('@Utils/colour-log')
 
 describe('exitHandler', () => {
 
-  beforeEach(() => {
-    jest.spyOn(console, 'log').mockImplementation(() => true)
-  })
-
-  it('exits with an exit code of 0', () => {
-    expect.assertions(3)
+  it('exits with an exit code of 0', async () => {
+    expect.assertions(2)
 
     try {
-      exitHandler(0, 'Normal Exit', undefined)
+      await exitHandler(0, 'Normal Exit', undefined)
     } catch {
       expect(colourLog.error).not.toHaveBeenCalled()
-      expect(console.log).toHaveBeenCalledOnceWith()
       expect(process.exit).toHaveBeenCalledOnceWith(0)
     }
   })
 
-  it('exits with an exit code of 1', () => {
-    expect.assertions(3)
+  it('exits with an exit code of 1', async () => {
+    expect.assertions(2)
 
     try {
-      exitHandler(1, 'Error Exit', undefined)
+      await exitHandler(1, 'Error Exit', undefined)
     } catch {
       expect(colourLog.error).not.toHaveBeenCalled()
-      expect(console.log).toHaveBeenCalledOnceWith()
       expect(process.exit).toHaveBeenCalledOnceWith(1)
     }
   })
 
-  it('logs an error when the exit code is 1 and there is an error', () => {
-    expect.assertions(3)
+  it('logs an error when the exit code is 1 and there is an error', async () => {
+    expect.assertions(2)
 
-    const err = new Error('Test Error')
+    const error = new Error('Test Error')
 
     try {
-      exitHandler(1, 'Error Exit', undefined, err)
+      await exitHandler(1, 'Error Exit', undefined, error)
     } catch {
-      expect(colourLog.error).toHaveBeenCalledOnceWith('Error Exit', err)
-      expect(console.log).toHaveBeenCalledOnceWith()
+      expect(colourLog.error).toHaveBeenCalledOnceWith('Error Exit', error)
       expect(process.exit).toHaveBeenCalledOnceWith(1)
     }
   })
 
-  it('closes the watcher if provided', () => {
-    expect.assertions(3)
+  it('closes the watcher if provided', async () => {
+    expect.assertions(2)
 
-    const mockWatcher = { close: jest.fn() }
+    const mockWatcher = { close: jest.fn() } as unknown as FSWatcher
 
     try {
-      exitHandler(0, 'Normal Exit', mockWatcher as Partial<FSWatcher> as FSWatcher)
+      await exitHandler(0, 'Normal Exit', mockWatcher)
     } catch {
       expect(mockWatcher.close).toHaveBeenCalled()
-      expect(console.log).toHaveBeenCalledOnceWith()
       expect(process.exit).toHaveBeenCalledOnceWith(0)
     }
   })

--- a/src/__tests__/exit-handler.spec.ts
+++ b/src/__tests__/exit-handler.spec.ts
@@ -10,7 +10,7 @@ describe('exitHandler', () => {
     expect.assertions(2)
 
     try {
-      await exitHandler(0, 'Normal Exit', undefined)
+      await exitHandler(0, 'SIGINT', undefined)
     } catch {
       expect(colourLog.error).not.toHaveBeenCalled()
       expect(process.exit).toHaveBeenCalledOnceWith(0)
@@ -21,37 +21,88 @@ describe('exitHandler', () => {
     expect.assertions(2)
 
     try {
-      await exitHandler(1, 'Error Exit', undefined)
+      await exitHandler(1, 'Unexpected Error', undefined)
     } catch {
       expect(colourLog.error).not.toHaveBeenCalled()
       expect(process.exit).toHaveBeenCalledOnceWith(1)
     }
   })
 
-  it('logs an error when the exit code is 1 and there is an error', async () => {
-    expect.assertions(2)
+  describe('when there is an error', () => {
 
-    const error = new Error('Test Error')
+    it('logs the error', async () => {
+      expect.assertions(2)
 
-    try {
-      await exitHandler(1, 'Error Exit', undefined, error)
-    } catch {
-      expect(colourLog.error).toHaveBeenCalledOnceWith('Error Exit', error)
-      expect(process.exit).toHaveBeenCalledOnceWith(1)
-    }
+      const error = new Error('Test Error')
+
+      try {
+        await exitHandler(1, 'Unexpected Error', undefined, error)
+      } catch {
+        expect(colourLog.error).toHaveBeenCalledOnceWith('Unexpected Error', error)
+        expect(process.exit).toHaveBeenCalledOnceWith(1)
+      }
+    })
+
   })
 
-  it('closes the watcher if provided', async () => {
-    expect.assertions(2)
+  describe('when a watcher is provided', () => {
 
-    const mockWatcher = { close: jest.fn() } as unknown as FSWatcher
+    it('closes the watcher', async () => {
+      expect.assertions(3)
 
-    try {
-      await exitHandler(0, 'Normal Exit', mockWatcher)
-    } catch {
-      expect(mockWatcher.close).toHaveBeenCalled()
-      expect(process.exit).toHaveBeenCalledOnceWith(0)
-    }
+      const mockWatcher = {
+        close: jest.fn(),
+      } as unknown as FSWatcher
+
+      try {
+        await exitHandler(0, 'SIGINT', mockWatcher)
+      } catch {
+        expect(mockWatcher.close).toHaveBeenCalledTimes(1)
+        expect(colourLog.error).not.toHaveBeenCalled()
+        expect(process.exit).toHaveBeenCalledOnceWith(0)
+      }
+    })
+
+    it('logs an error if the watcher fails to close', async () => {
+      expect.assertions(3)
+
+      const closeError = new Error('Close Error')
+      const mockWatcher = {
+        close: jest.fn(() => Promise.reject(closeError)),
+      } as unknown as FSWatcher
+
+      try {
+        await exitHandler(0, 'SIGINT', mockWatcher)
+      } catch {
+        expect(mockWatcher.close).toHaveBeenCalledTimes(1)
+        expect(colourLog.error).toHaveBeenCalledOnceWith('Failed to close file watcher', closeError)
+        expect(process.exit).toHaveBeenCalledOnceWith(0)
+      }
+    })
+
+    it('exits if the watcher fails to close after 5 seconds', async () => {
+      expect.assertions(3)
+      jest.useFakeTimers()
+
+      const mockWatcher = {
+        close: jest.fn(() => new Promise(() => {
+          // Never resolves - simulates hanging watcher
+        })),
+      } as unknown as FSWatcher
+
+      const exitPromise = exitHandler(0, 'SIGINT', mockWatcher)
+
+      jest.advanceTimersByTime(5000)
+
+      try {
+        await exitPromise
+      } catch {
+        expect(mockWatcher.close).toHaveBeenCalledTimes(1)
+        expect(colourLog.error).toHaveBeenCalledOnceWith('Failed to close file watcher', new Error('Watcher close timeout'))
+        expect(process.exit).toHaveBeenCalledOnceWith(0)
+      }
+    })
+
   })
 
 })

--- a/src/exit-handler.ts
+++ b/src/exit-handler.ts
@@ -4,21 +4,20 @@ import type { FSWatcher } from 'chokidar'
 
 type ExitCode = 0 | 1
 
-const exitHandler = (
+const exitHandler = async (
   exitCode: ExitCode,
   reason: string,
   watcher: FSWatcher | undefined,
   error?: Error | string | unknown
-) => {
+): Promise<never> => {
   if (exitCode === 1 && error) {
     colourLog.error(reason, error)
   }
 
   if (watcher) {
-    watcher.close()
+    await watcher.close()
   }
 
-  console.log()
   process.exit(exitCode)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,6 @@ const program = createProgram({
   setWatcher: (w: FSWatcher) => { watcher = w },
 })
 
-program.parseAsync(process.argv)
+program.parseAsync(process.argv).catch(error =>
+  exitHandler(1, 'Program Parse Error', watcher, error)
+)

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ process.on('uncaughtException', error => exitHandler(1, 'Unexpected Error', watc
 process.on('unhandledRejection', error => exitHandler(1, 'Unhandled Promise', watcher, error))
 
 const program = createProgram({
-  setWatcher: (w: FSWatcher) => watcher = w
+  setWatcher: (w: FSWatcher) => { watcher = w },
 })
 
 program.parseAsync(process.argv)

--- a/src/linters/eslint/__tests__/lint-files.spec.ts
+++ b/src/linters/eslint/__tests__/lint-files.spec.ts
@@ -7,7 +7,6 @@ import colourLog from '@Utils/colour-log'
 import lintFiles from '../lint-files'
 
 jest.mock('eslint')
-jest.mock('@Utils/colour-log')
 
 describe('lintFiles', () => {
 

--- a/src/linters/eslint/lint-files.ts
+++ b/src/linters/eslint/lint-files.ts
@@ -18,7 +18,7 @@ const lintFiles = async ({ cache, eslintUseLegacyConfig, files, fix }: LintFiles
     // Run ESLint
     const results = await new ESLint({
       cache,
-      cacheLocation: cache ? getCacheDirectory('eslint') : undefined,
+      cacheLocation: cache ? getCacheDirectory(Linter.ESLint) : undefined,
       fix,
     }).lintFiles(files)
 

--- a/src/linters/eslint/process-results.ts
+++ b/src/linters/eslint/process-results.ts
@@ -37,7 +37,7 @@ const processResults = (results: Array<ESLint.LintResult>): LintReport => {
 
       reportResults[file].push(formatResult({
         column,
-        lineNumber: line,
+        line,
         message,
         rule: ruleId || 'core-error',
         severity: severity === 1 ? RuleSeverity.WARNING : RuleSeverity.ERROR,

--- a/src/linters/markdownlint/__tests__/lint-files.spec.ts
+++ b/src/linters/markdownlint/__tests__/lint-files.spec.ts
@@ -6,7 +6,6 @@ import lintFiles from '../lint-files'
 import { loadConfig } from '../load-config'
 import { markdownlintAsync } from '../markdownlint-async'
 
-jest.mock('@Utils/colour-log')
 jest.mock('../fix-file')
 jest.mock('../load-config')
 jest.mock('../markdownlint-async')

--- a/src/linters/markdownlint/__tests__/load-config.spec.ts
+++ b/src/linters/markdownlint/__tests__/load-config.spec.ts
@@ -11,7 +11,6 @@ jest.mock('node:fs')
 jest.mock('markdownlint', () => ({
   readConfigSync: jest.fn().mockImplementation(() => ({ default: true })),
 }))
-jest.mock('@Utils/colour-log')
 
 describe('loadConfig', () => {
 

--- a/src/linters/markdownlint/process-results.ts
+++ b/src/linters/markdownlint/process-results.ts
@@ -32,7 +32,7 @@ const processResults = (results: LintResults): LintReport => {
       .forEach(({ errorDetail, errorRange, fixInfo, lineNumber, ruleDescription, ruleNames }) => {
         reportResults[file].push(formatResult({
           column: errorRange?.length ? errorRange[0] : undefined,
-          lineNumber,
+          line: lineNumber,
           message: errorDetail?.length ? `${ruleDescription}: ${errorDetail}` : ruleDescription,
           rule: ruleNames.at(1) ?? ruleNames[0],
           severity: RuleSeverity.ERROR,

--- a/src/linters/stylelint/__tests__/lint-files.spec.ts
+++ b/src/linters/stylelint/__tests__/lint-files.spec.ts
@@ -11,7 +11,6 @@ import type { LintResult } from 'stylelint'
 jest.mock('stylelint', () => ({
   lint: jest.fn(),
 }))
-jest.mock('@Utils/colour-log')
 
 describe('lintFiles', () => {
 

--- a/src/linters/stylelint/lint-files.ts
+++ b/src/linters/stylelint/lint-files.ts
@@ -14,7 +14,7 @@ const lintFiles = async ({ cache, files, fix }: LintFilesOptions): Promise<LintR
     const { results, ruleMetadata } = await stylelint.lint({
       allowEmptyInput: true,
       cache,
-      cacheLocation: cache ? getCacheDirectory('stylelint') : undefined,
+      cacheLocation: cache ? getCacheDirectory(Linter.Stylelint) : undefined,
       config: { // TODO: Replace with externally loaded or user-provided Stylelint config
         rules: {
           'declaration-block-no-duplicate-properties': true,

--- a/src/linters/stylelint/process-results.ts
+++ b/src/linters/stylelint/process-results.ts
@@ -35,7 +35,7 @@ const processResults = (results: Array<LintResult>, ruleMetadata: RuleMetadata):
 
       reportResults[file].push(formatResult({
         column,
-        lineNumber: line,
+        line,
         message: text.replace(`(${rule})`, ''),
         rule,
         severity: isWarning ? RuleSeverity.WARNING : RuleSeverity.ERROR,

--- a/src/utils/__tests__/cache.spec.ts
+++ b/src/utils/__tests__/cache.spec.ts
@@ -1,15 +1,17 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+import { Linter } from '@Types/lint'
 import colourLog from '@Utils/colour-log'
 
 import { clearCacheDirectory, getCacheDirectory } from '../cache'
 
 jest.mock('node:fs')
 
-describe('clearCacheDirectory', () => {
+const expectedCacheDirectory = path.join(process.cwd(), '.cache/lint')
+const expectedCacheSubDirectory = path.join(expectedCacheDirectory, 'eslint')
 
-  const expectedCacheDirectory = `${process.cwd()}/.cache/lint`
+describe('clearCacheDirectory', () => {
 
   it('clears the cache directory if it exists', () => {
     jest.mocked(fs.existsSync).mockReturnValueOnce(true)
@@ -24,17 +26,17 @@ describe('clearCacheDirectory', () => {
     expect(colourLog.info).toHaveBeenCalledOnceWith('Cache cleared.\n')
   })
 
-  it('clears a cache sub-directory if it exists', () => {
+  it('clears the cache directory for a specific linter if it exists', () => {
     jest.mocked(fs.existsSync).mockReturnValueOnce(true)
 
-    clearCacheDirectory('eslint')
+    clearCacheDirectory(Linter.ESLint)
 
-    expect(fs.existsSync).toHaveBeenCalledOnceWith(`${expectedCacheDirectory}/eslint`)
-    expect(fs.rmSync).toHaveBeenCalledOnceWith(`${expectedCacheDirectory}/eslint`, {
+    expect(fs.existsSync).toHaveBeenCalledOnceWith(expectedCacheSubDirectory)
+    expect(fs.rmSync).toHaveBeenCalledOnceWith(expectedCacheSubDirectory, {
       force: true,
       recursive: true,
     })
-    expect(colourLog.info).toHaveBeenCalledOnceWith('Cache cleared for eslint.\n')
+    expect(colourLog.info).toHaveBeenCalledOnceWith('Cache cleared for ESLint.\n')
   })
 
   it('does not attempt to clear the cache if the directory does not exist', () => {
@@ -47,27 +49,27 @@ describe('clearCacheDirectory', () => {
     expect(colourLog.info).toHaveBeenCalledOnceWith('No cache to clear.\n')
   })
 
-  it('does not attempt to clear the cache if the sub-directory does not exist', () => {
+  it('does not attempt to clear the cache for a specific linter if the directory does not exist', () => {
     jest.mocked(fs.existsSync).mockReturnValueOnce(false)
 
-    clearCacheDirectory('eslint')
+    clearCacheDirectory(Linter.ESLint)
 
-    expect(fs.existsSync).toHaveBeenCalledOnceWith(`${expectedCacheDirectory}/eslint`)
+    expect(fs.existsSync).toHaveBeenCalledOnceWith(expectedCacheSubDirectory)
     expect(fs.rmSync).not.toHaveBeenCalled()
-    expect(colourLog.info).toHaveBeenCalledOnceWith('No cache to clear for eslint.\n')
+    expect(colourLog.info).toHaveBeenCalledOnceWith('No cache to clear for ESLint.\n')
   })
 
 })
 
 describe('getCacheDirectory', () => {
 
-  it('returns the resolved path to a cache sub-directory', () => {
+  it('returns the resolved path to a cache directory', () => {
     jest.spyOn(path, 'resolve')
 
-    const result = getCacheDirectory('eslint')
+    const result = getCacheDirectory(Linter.ESLint)
 
     expect(path.resolve).toHaveBeenCalledOnceWith(process.cwd(), '.cache/lint', 'eslint')
-    expect(result).toBe(`${process.cwd()}/.cache/lint/eslint`)
+    expect(result).toBe(expectedCacheSubDirectory)
   })
 
 })

--- a/src/utils/__tests__/cache.spec.ts
+++ b/src/utils/__tests__/cache.spec.ts
@@ -6,7 +6,6 @@ import colourLog from '@Utils/colour-log'
 import { clearCacheDirectory, getCacheDirectory } from '../cache'
 
 jest.mock('node:fs')
-jest.mock('@Utils/colour-log')
 
 describe('clearCacheDirectory', () => {
 

--- a/src/utils/__tests__/cache.spec.ts
+++ b/src/utils/__tests__/cache.spec.ts
@@ -8,8 +8,13 @@ import { clearCacheDirectory, getCacheDirectory } from '../cache'
 
 jest.mock('node:fs')
 
-const expectedCacheDirectory = path.join(process.cwd(), '.cache/lint')
-const expectedCacheSubDirectory = path.join(expectedCacheDirectory, 'eslint')
+const cacheDirectory = path.join(process.cwd(), '.cache/lint')
+
+const testCases: Array<[Linter, string]> = [
+  [Linter.ESLint, 'eslint'],
+  [Linter.Markdownlint, 'markdownlint'],
+  [Linter.Stylelint, 'stylelint'],
+]
 
 describe('clearCacheDirectory', () => {
 
@@ -18,25 +23,27 @@ describe('clearCacheDirectory', () => {
 
     clearCacheDirectory()
 
-    expect(fs.existsSync).toHaveBeenCalledOnceWith(expectedCacheDirectory)
-    expect(fs.rmSync).toHaveBeenCalledOnceWith(expectedCacheDirectory, {
+    expect(fs.existsSync).toHaveBeenCalledOnceWith(cacheDirectory)
+    expect(fs.rmSync).toHaveBeenCalledOnceWith(cacheDirectory, {
       force: true,
       recursive: true,
     })
     expect(colourLog.info).toHaveBeenCalledOnceWith('Cache cleared.\n')
   })
 
-  it('clears the cache directory for a specific linter if it exists', () => {
+  test.each(testCases)('clears the cache directory for %s if it exists', (linter, expectedSubDirectory) => {
+    const expectedCacheDirectory = path.join(cacheDirectory, expectedSubDirectory)
+
     jest.mocked(fs.existsSync).mockReturnValueOnce(true)
 
-    clearCacheDirectory(Linter.ESLint)
+    clearCacheDirectory(linter)
 
-    expect(fs.existsSync).toHaveBeenCalledOnceWith(expectedCacheSubDirectory)
-    expect(fs.rmSync).toHaveBeenCalledOnceWith(expectedCacheSubDirectory, {
+    expect(fs.existsSync).toHaveBeenCalledOnceWith(expectedCacheDirectory)
+    expect(fs.rmSync).toHaveBeenCalledOnceWith(expectedCacheDirectory, {
       force: true,
       recursive: true,
     })
-    expect(colourLog.info).toHaveBeenCalledOnceWith('Cache cleared for ESLint.\n')
+    expect(colourLog.info).toHaveBeenCalledOnceWith(`Cache cleared for ${linter}.\n`)
   })
 
   it('does not attempt to clear the cache if the directory does not exist', () => {
@@ -44,32 +51,70 @@ describe('clearCacheDirectory', () => {
 
     clearCacheDirectory()
 
-    expect(fs.existsSync).toHaveBeenCalledOnceWith(expectedCacheDirectory)
+    expect(fs.existsSync).toHaveBeenCalledOnceWith(cacheDirectory)
     expect(fs.rmSync).not.toHaveBeenCalled()
     expect(colourLog.info).toHaveBeenCalledOnceWith('No cache to clear.\n')
   })
 
-  it('does not attempt to clear the cache for a specific linter if the directory does not exist', () => {
+  test.each(testCases)('does not attempt to clear the cache for %s if the directory does not exist', (linter, expectedSubDirectory) => {
+    const expectedCacheDirectory = path.join(cacheDirectory, expectedSubDirectory)
+
     jest.mocked(fs.existsSync).mockReturnValueOnce(false)
 
-    clearCacheDirectory(Linter.ESLint)
+    clearCacheDirectory(linter)
 
-    expect(fs.existsSync).toHaveBeenCalledOnceWith(expectedCacheSubDirectory)
+    expect(fs.existsSync).toHaveBeenCalledOnceWith(expectedCacheDirectory)
     expect(fs.rmSync).not.toHaveBeenCalled()
-    expect(colourLog.info).toHaveBeenCalledOnceWith('No cache to clear for ESLint.\n')
+    expect(colourLog.info).toHaveBeenCalledOnceWith(`No cache to clear for ${linter}.\n`)
+  })
+
+  it('logs an error if clearing the cache fails', () => {
+    jest.mocked(fs.existsSync).mockReturnValueOnce(true)
+    jest.mocked(fs.rmSync).mockImplementationOnce(() => {
+      throw new Error('Test Error')
+    })
+
+    clearCacheDirectory()
+
+    expect(fs.existsSync).toHaveBeenCalledOnceWith(cacheDirectory)
+    expect(fs.rmSync).toHaveBeenCalledOnceWith(cacheDirectory, {
+      force: true,
+      recursive: true,
+    })
+    expect(colourLog.error).toHaveBeenCalledOnceWith('Failed to clear cache.\n', expect.any(Error))
+  })
+
+  test.each(testCases)('logs an error if clearing the cache fails for %s', (linter, expectedSubDirectory) => {
+    const expectedCacheDirectory = path.join(cacheDirectory, expectedSubDirectory)
+
+    jest.mocked(fs.existsSync).mockReturnValueOnce(true)
+    jest.mocked(fs.rmSync).mockImplementationOnce(() => {
+      throw new Error('Test Error')
+    })
+
+    clearCacheDirectory(linter)
+
+    expect(fs.existsSync).toHaveBeenCalledOnceWith(expectedCacheDirectory)
+    expect(fs.rmSync).toHaveBeenCalledOnceWith(expectedCacheDirectory, {
+      force: true,
+      recursive: true,
+    })
+    expect(colourLog.error).toHaveBeenCalledOnceWith(`Failed to clear cache for ${linter}.\n`, expect.any(Error))
   })
 
 })
 
 describe('getCacheDirectory', () => {
 
-  it('returns the resolved path to a cache directory', () => {
+  test.each(testCases)('returns the resolved path to the %s cache directory', (linter, expectedSubDirectory) => {
     jest.spyOn(path, 'resolve')
 
-    const result = getCacheDirectory(Linter.ESLint)
+    const expectedCacheDirectory = path.join(cacheDirectory, expectedSubDirectory)
 
-    expect(path.resolve).toHaveBeenCalledOnceWith(process.cwd(), '.cache/lint', 'eslint')
-    expect(result).toBe(expectedCacheSubDirectory)
+    const result = getCacheDirectory(linter)
+
+    expect(path.resolve).toHaveBeenCalledOnceWith(process.cwd(), '.cache/lint', expectedSubDirectory)
+    expect(result).toBe(expectedCacheDirectory)
   })
 
 })

--- a/src/utils/__tests__/colour-log.spec.ts
+++ b/src/utils/__tests__/colour-log.spec.ts
@@ -26,6 +26,8 @@ jest.mock('chalk', () => ({
 
 jest.mock('space-log')
 
+jest.unmock('@Utils/colour-log')
+
 jest.useFakeTimers().setSystemTime(1718971200)
 
 describe('colourLog', () => {

--- a/src/utils/__tests__/colour-log.spec.ts
+++ b/src/utils/__tests__/colour-log.spec.ts
@@ -28,8 +28,6 @@ jest.mock('space-log')
 
 jest.unmock('@Utils/colour-log')
 
-jest.useFakeTimers().setSystemTime(1718971200)
-
 describe('colourLog', () => {
 
   const mockedConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {})
@@ -205,8 +203,7 @@ describe('colourLog', () => {
 
   describe('summary', () => {
 
-    const startTime = new Date().getTime()
-    jest.advanceTimersByTime(1000)
+    let startTime: number
 
     const expectResult = () => {
       expect(chalk.cyan).toHaveBeenCalledWith('Finished eslint')
@@ -214,6 +211,12 @@ describe('colourLog', () => {
       expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
       expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nFinished eslint', '[1 file, 1000ms]')
     }
+
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(1718971200)
+      startTime = new Date().getTime()
+      jest.advanceTimersByTime(1000)
+    })
 
     it('logs the finished lint message along with the file count and duration (single file)', () => {
       colourLog.summary(commonSummary, startTime)

--- a/src/utils/__tests__/file-patterns.spec.ts
+++ b/src/utils/__tests__/file-patterns.spec.ts
@@ -3,8 +3,6 @@ import colourLog from '@Utils/colour-log'
 
 import { getFilePatterns } from '../file-patterns'
 
-jest.mock('@Utils/colour-log')
-
 describe('getFilePatterns', () => {
 
   beforeEach(() => {

--- a/src/utils/__tests__/file-patterns.spec.ts
+++ b/src/utils/__tests__/file-patterns.spec.ts
@@ -146,22 +146,22 @@ describe('getFilePatterns', () => {
     getFilePatterns({})
 
     expect(colourLog.config).toHaveBeenCalledTimes(4)
-    expect(colourLog.config).toHaveBeenCalledWith('ESLint Patterns', expect.any(Array))
-    expect(colourLog.config).toHaveBeenCalledWith('Markdownlint Patterns', expect.any(Array))
-    expect(colourLog.config).toHaveBeenCalledWith('Stylelint Patterns', expect.any(Array))
-    expect(colourLog.config).toHaveBeenCalledWith('Ignore', expect.any(Array))
+    expect(colourLog.config).toHaveBeenNthCalledWith(1, 'ESLint Patterns', expect.any(Array))
+    expect(colourLog.config).toHaveBeenNthCalledWith(2, 'Markdownlint Patterns', expect.any(Array))
+    expect(colourLog.config).toHaveBeenNthCalledWith(3, 'Stylelint Patterns', expect.any(Array))
+    expect(colourLog.config).toHaveBeenNthCalledWith(4, 'Ignore', expect.any(Array))
     expect(console.log).toHaveBeenCalledOnceWith()
   })
 
   test.each([
-    [Linter.ESLint, 'ESLint Patterns'],
-    [Linter.Markdownlint, 'Markdownlint Patterns'],
-    [Linter.Stylelint, 'Stylelint Patterns'],
-  ])('logs the file patterns for %s when specified', (linter, patternName) => {
+    Linter.ESLint,
+    Linter.Markdownlint,
+    Linter.Stylelint,
+  ])('logs the file patterns for %s when specified', linter => {
     getFilePatterns({ linters: [linter] })
 
     expect(colourLog.config).toHaveBeenCalledTimes(2)
-    expect(colourLog.config).toHaveBeenNthCalledWith(1, patternName, expect.any(Array))
+    expect(colourLog.config).toHaveBeenNthCalledWith(1, `${linter} Patterns`, expect.any(Array))
     expect(colourLog.config).toHaveBeenNthCalledWith(2, 'Ignore', expect.any(Array))
     expect(console.log).toHaveBeenCalledOnceWith()
   })

--- a/src/utils/__tests__/format-result.spec.ts
+++ b/src/utils/__tests__/format-result.spec.ts
@@ -8,7 +8,7 @@ describe('formatResult', () => {
 
   const commonResult = {
     column: 5,
-    lineNumber: 10,
+    line: 10,
     message: 'Test message',
     rule: 'test-rule',
     severity: RuleSeverity.ERROR,
@@ -53,6 +53,19 @@ describe('formatResult', () => {
     expect(formattedResult).toStrictEqual({
       ...commonFormattedResult,
       position: '10',
+    })
+  })
+
+  it('formats a result without a line', () => {
+    const formattedResult = formatResult({
+      ...commonResult,
+      column: undefined,
+      line: undefined,
+    })
+
+    expect(formattedResult).toStrictEqual({
+      ...commonFormattedResult,
+      position: '0',
     })
   })
 

--- a/src/utils/__tests__/notifier.spec.ts
+++ b/src/utils/__tests__/notifier.spec.ts
@@ -123,4 +123,17 @@ describe('notifyResults', () => {
     })
   })
 
+  it('does not throw if notifier fails', () => {
+    (notifier.notify as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('Notification failed')
+    })
+
+    const exitCode = notifyResults([
+      generateReport(0, 0),
+      generateReport(0, 0),
+    ], 'Lint Pilot')
+
+    expect(exitCode).toBe(0)
+  })
+
 })

--- a/src/utils/__tests__/source-files.spec.ts
+++ b/src/utils/__tests__/source-files.spec.ts
@@ -8,7 +8,6 @@ import { sourceFiles } from '../source-files'
 import type { FilePatterns } from '@Types/lint'
 
 jest.mock('glob')
-jest.mock('@Utils/colour-log')
 
 describe('sourceFiles', () => {
 

--- a/src/utils/__tests__/source-files.spec.ts
+++ b/src/utils/__tests__/source-files.spec.ts
@@ -95,7 +95,7 @@ describe('sourceFiles', () => {
     try {
       await sourceFiles(getFilePatterns(), Linter.ESLint)
     } catch {
-      expect(colourLog.error).toHaveBeenCalledOnceWith('An error occurred while sourcing files for ESLint', error)
+      expect(colourLog.error).toHaveBeenCalledOnceWith('Failed to source files for ESLint', error)
       expect(process.exit).toHaveBeenCalledOnceWith(1)
     }
   })

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,27 +1,26 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+import { Linter } from '@Types/lint'
 import colourLog from '@Utils/colour-log'
-
-type CacheSubDirectory = 'eslint' | 'stylelint'
 
 const CACHE_DIRECTORY = '.cache/lint'
 
-const clearCacheDirectory = (subDir?: CacheSubDirectory) => {
-  const cacheDirectory = path.resolve(process.cwd(), CACHE_DIRECTORY, subDir || '')
+const clearCacheDirectory = (linter?: Linter) => {
+  const cacheDirectory = path.resolve(process.cwd(), CACHE_DIRECTORY, linter?.toLowerCase() || '')
 
   if (fs.existsSync(cacheDirectory)) {
     fs.rmSync(cacheDirectory, {
       force: true,
       recursive: true,
     })
-    colourLog.info(`Cache cleared${subDir ? ` for ${subDir}` : ''}.\n`)
+    colourLog.info(`Cache cleared${linter ? ` for ${linter}` : ''}.\n`)
   } else {
-    colourLog.info(`No cache to clear${subDir ? ` for ${subDir}` : ''}.\n`)
+    colourLog.info(`No cache to clear${linter ? ` for ${linter}` : ''}.\n`)
   }
 }
 
-const getCacheDirectory = (subDir: CacheSubDirectory) => path.resolve(process.cwd(), CACHE_DIRECTORY, subDir)
+const getCacheDirectory = (linter: Linter) => path.resolve(process.cwd(), CACHE_DIRECTORY, linter?.toLowerCase())
 
 export {
   clearCacheDirectory,

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,26 +1,33 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { Linter } from '@Types/lint'
 import colourLog from '@Utils/colour-log'
+
+import type { Linter } from '@Types/lint'
 
 const CACHE_DIRECTORY = '.cache/lint'
 
 const clearCacheDirectory = (linter?: Linter) => {
-  const cacheDirectory = path.resolve(process.cwd(), CACHE_DIRECTORY, linter?.toLowerCase() || '')
+  const messageSuffix = linter ? ` for ${linter}` : ''
 
-  if (fs.existsSync(cacheDirectory)) {
-    fs.rmSync(cacheDirectory, {
-      force: true,
-      recursive: true,
-    })
-    colourLog.info(`Cache cleared${linter ? ` for ${linter}` : ''}.\n`)
-  } else {
-    colourLog.info(`No cache to clear${linter ? ` for ${linter}` : ''}.\n`)
+  try {
+    const cacheDirectory = path.resolve(process.cwd(), CACHE_DIRECTORY, linter?.toLowerCase() || '')
+
+    if (fs.existsSync(cacheDirectory)) {
+      fs.rmSync(cacheDirectory, {
+        force: true,
+        recursive: true,
+      })
+      colourLog.info(`Cache cleared${messageSuffix}.\n`)
+    } else {
+      colourLog.info(`No cache to clear${messageSuffix}.\n`)
+    }
+  } catch (error) {
+    colourLog.error(`Failed to clear cache${messageSuffix}.\n`, error)
   }
 }
 
-const getCacheDirectory = (linter: Linter) => path.resolve(process.cwd(), CACHE_DIRECTORY, linter?.toLowerCase())
+const getCacheDirectory = (linter: Linter) => path.resolve(process.cwd(), CACHE_DIRECTORY, linter.toLowerCase())
 
 export {
   clearCacheDirectory,

--- a/src/utils/file-patterns.ts
+++ b/src/utils/file-patterns.ts
@@ -42,15 +42,11 @@ const getFilePatterns = ({ eslintInclude = [], ignoreDirs = [], ignorePatterns =
     ],
   }
 
-  if (!linters || linters.includes(Linter.ESLint)) {
-    colourLog.config('ESLint Patterns', filePatterns.includePatterns[Linter.ESLint])
-  }
-  if (!linters || linters.includes(Linter.Markdownlint)) {
-    colourLog.config('Markdownlint Patterns', filePatterns.includePatterns[Linter.Markdownlint])
-  }
-  if (!linters || linters.includes(Linter.Stylelint)) {
-    colourLog.config('Stylelint Patterns', filePatterns.includePatterns[Linter.Stylelint])
-  }
+  Object.values(Linter).forEach(linter => {
+    if (!linters || linters.includes(linter)) {
+      colourLog.config(`${linter} Patterns`, filePatterns.includePatterns[linter])
+    }
+  })
   colourLog.config('Ignore', filePatterns.ignorePatterns)
   console.log()
 

--- a/src/utils/format-result.ts
+++ b/src/utils/format-result.ts
@@ -6,16 +6,16 @@ import type { FormattedResult } from '@Types/lint'
 
 interface Result {
   column?: number
-  lineNumber: number
+  line?: number
   message: string
   rule: string
   severity: RuleSeverity
 }
 
-const formatResult = ({ column, lineNumber, message, rule, severity }: Result): FormattedResult => ({
+const formatResult = ({ column, line = 0, message, rule, severity }: Result): FormattedResult => ({
   message: message.trim(),
   messageTheme: chalk.white,
-  position: column ? `${lineNumber}:${column}` : lineNumber.toString(),
+  position: column ? `${line}:${column}` : line.toString(),
   positionTheme: chalk.dim,
   rule,
   ruleTheme: chalk.dim,

--- a/src/utils/notifier.ts
+++ b/src/utils/notifier.ts
@@ -2,15 +2,24 @@ import notifier from 'node-notifier'
 
 import { pluralise } from '@Utils/transform'
 
+import type { Notification } from 'node-notifier/notifiers/notificationcenter'
 import type { LintReport } from '@Types/lint'
 
 type ExitCode = 0 | 1
 
+const notifyFailSafe = (options: Notification) => {
+  try {
+    notifier.notify(options)
+  } catch {
+    // Intentionally empty - notifications are optional
+  }
+}
+
 const notifyResults = (reports: Array<LintReport>, title: string): ExitCode => {
   // Errors
-  let totalErrorCount = reports.reduce((total, { summary: { errorCount } }) => total + errorCount, 0)
+  const totalErrorCount = reports.reduce((total, { summary: { errorCount } }) => total + errorCount, 0)
   if (totalErrorCount > 0) {
-    notifier.notify({
+    notifyFailSafe({
       message: `${totalErrorCount} ${pluralise('error', totalErrorCount)} found. Please fix ${totalErrorCount === 1 ? 'it ' : 'them '}before continuing.`,
       sound: 'Frog',
       title: `🚨 ${title}`,
@@ -19,9 +28,9 @@ const notifyResults = (reports: Array<LintReport>, title: string): ExitCode => {
   }
 
   // Warnings
-  let totalWarningCount = reports.reduce((total, { summary: { warningCount } }) => total + warningCount, 0)
+  const totalWarningCount = reports.reduce((total, { summary: { warningCount } }) => total + warningCount, 0)
   if (totalWarningCount > 0) {
-    notifier.notify({
+    notifyFailSafe({
       message: `${totalWarningCount} ${pluralise('warning', totalWarningCount)} found. Please review ${totalWarningCount === 1 ? '' : 'them '}before continuing.`,
       sound: 'Frog',
       title: `⚠️ ${title}`,
@@ -30,7 +39,7 @@ const notifyResults = (reports: Array<LintReport>, title: string): ExitCode => {
   }
 
   // Success
-  notifier.notify({
+  notifyFailSafe({
     message: 'All lint checks have passed. Your code is clean!',
     sound: 'Purr',
     title: `✅ ${title}`,

--- a/src/utils/source-files.ts
+++ b/src/utils/source-files.ts
@@ -5,17 +5,15 @@ import { pluralise } from '@Utils/transform'
 
 import type { FilePatterns, Linter } from '@Types/lint'
 
-type FileList = Array<string>
+const sourceFiles = async ({ ignorePatterns, includePatterns }: FilePatterns, linter: Linter): Promise<Array<string>> => {
+  const include = includePatterns[linter]
 
-const sourceFiles = async ({ includePatterns, ignorePatterns }: FilePatterns, linter: Linter): Promise<FileList> => {
+  if (!include.length) {
+    colourLog.warning(`\nNo file patterns provided for ${linter}. Skipping.`)
+    return []
+  }
+
   try {
-    const include = includePatterns[linter]
-
-    if (!include.length) {
-      colourLog.warning(`\nNo file patterns provided for ${linter}. Skipping.`)
-      return []
-    }
-
     const files = [...new Set(await glob(include, {
       ignore: ignorePatterns,
     }))]
@@ -28,7 +26,7 @@ const sourceFiles = async ({ includePatterns, ignorePatterns }: FilePatterns, li
     colourLog.configDebug(`Sourced ${files.length} ${pluralise('file', files.length)} for ${linter}:`, files)
     return files
   } catch (error) {
-    colourLog.error(`An error occurred while sourcing files for ${linter}`, error)
+    colourLog.error(`Failed to source files for ${linter}`, error)
     process.exit(1)
   }
 }


### PR DESCRIPTION
## Details

### What have you changed?
<!-- List changes in past tense -->
- 🃏 Mocked `@Utils/colour-log` globally.

- 🤡 Simplified the `toHaveBeenCalledOnceWith` Jest matcher.

- 🛑 Made the `exitHandler` function asynchronous and `await` the `watcher.close` call with a 5-second limit in case the process hangs.

- 🗂️ Clarified cache directory logic for specific linters.

- ⏱️ Added a debounce when firing file-changed events.

### Why are you making these changes?
<!-- List reasons in past tense -->
- 🃏 Each file using `colourLog` previously needed to mock it in its own tests. Mocking it globally simplifies setup and allows unmocking in one place.

- 🤡 The matcher became easier to read and reason with.

- 🛑 Ensured the watcher closes before the process exits, while preventing the process from hanging indefinitely.

- 🗂️ Made cache management clearer and more consistent by explicitly associating cache directories with named linters.

- ⏱️ Prevented rapid saves from triggering too many events.
