### PR TITLE
Rename the project to yuna (yunalint) 🌺

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌸 Yuna
+# 🌺 Yuna
 
 [![Test](https://github.com/01taylop/yunalint/actions/workflows/test.yml/badge.svg)](https://github.com/01taylop/yunalint/actions/workflows/test.yml)
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,32 @@
-# ✈️ Lint Pilot
+# 🌸 Yuna
 
-[![Test](https://github.com/01taylop/lint-pilot/actions/workflows/test.yml/badge.svg)](https://github.com/01taylop/lint-pilot/actions/workflows/test.yml)
+[![Test](https://github.com/01taylop/yunalint/actions/workflows/test.yml/badge.svg)](https://github.com/01taylop/yunalint/actions/workflows/test.yml)
 
 ![Node Versions Supported](https://img.shields.io/static/v1?label=node&message=>=18.18.0&color=blue)
 
-Your co-pilot for maintaining high code quality with seamless ESLint, Stylelint, and Markdownlint integration.
+An opinionated linting orchestrator for ESLint, Stylelint, and Markdownlint.
 
 ## 🚧 Coming Soon
 
-Lint Pilot is currently under construction. Stay tuned for more information.
+Yuna is currently under construction. Stay tuned for more information.
 
 ## Markdown Lint
 
-Lint Pilot integrates with the popular [markdownlint](https://github.com/DavidAnson/markdownlint) plugin to ensure your Markdown files adhere to best practices and your specified style guide.
+Yuna integrates with the popular [markdownlint](https://github.com/DavidAnson/markdownlint) plugin to ensure your Markdown files adhere to best practices and your specified style guide.
 
 ### Default Rules
 
-Lint Pilot uses a set of default rules for Markdown linting, which can be found [here](./config/markdownlint.json). These rules are designed to cover a wide range of common Markdown issues, providing a solid foundation for most projects.
+Yuna uses a set of default rules for Markdown linting, which can be found [here](./config/markdownlint.json). These rules are designed to cover a wide range of common Markdown issues, providing a solid foundation for most projects.
 
 ### Customising Rules
 
-To customise or extend the default rules provided by Lint Pilot or markdownlint, you can create a `.markdownlint.json` file in your project root. This file allows you to modify existing rules or add new ones to fit your project's needs.
+To customise or extend the default rules provided by Yuna or markdownlint, you can create a `.markdownlint.json` file in your project root. This file allows you to modify existing rules or add new ones to fit your project's needs.
 
-The default rules set by Lint Pilot are located at `node_modules/lint-pilot/markdownlint.json`. To extend these rules, reference them in your `.markdownlint.json` file and then override or add to them as needed. For example:
+The default rules set by Yuna are located at `node_modules/yunalint/markdownlint.json`. To extend these rules, reference them in your `.markdownlint.json` file and then override or add to them as needed. For example:
 
 ```jsonc
 {
-  "extends": "./node_modules/lint-pilot/markdownlint.json",
+  "extends": "./node_modules/yunalint/markdownlint.json",
   "MD013": true, // Enable line length check
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "lint-pilot",
-  "description": "Your co-pilot for maintaining high code quality with seamless ESLint, Stylelint, and Markdownlint integration.",
+  "name": "yunalint",
+  "description": "An opinionated linting orchestrator for ESLint, Stylelint, and Markdownlint.",
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/01taylop/lint-pilot.git"
+    "url": "git+https://github.com/01taylop/yunalint.git"
   },
   "type": "module",
   "engines": {
     "node": ">=18.18.0"
   },
   "bin": {
-    "lint-pilot": "./lib/index.js"
+    "yuna": "./lib/index.js"
   },
   "files": [
     "lib"

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -35,13 +35,13 @@ describe('index - CLI integration', () => {
       cache: false,
       clearCache: false,
       debug: false,
-      emoji: '✈️',
+      emoji: '🌸',
       eslintInclude: undefined,
       eslintUseLegacyConfig: false,
       fix: false,
       ignoreDirs: undefined,
       ignorePatterns: undefined,
-      title: 'Lint Pilot',
+      title: 'Yuna',
       watch: false,
     }
 

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -35,7 +35,7 @@ describe('index - CLI integration', () => {
       cache: false,
       clearCache: false,
       debug: false,
-      emoji: '🌸',
+      emoji: '🌺',
       eslintInclude: undefined,
       eslintUseLegacyConfig: false,
       fix: false,

--- a/src/__tests__/program.spec.ts
+++ b/src/__tests__/program.spec.ts
@@ -81,7 +81,7 @@ describe('createProgram', () => {
 
     expect(chalk.red).toHaveBeenCalledOnceWith(expect.stringContaining('× unknown option \'--unknown\''))
     expect(writeErrMock).toHaveBeenNthCalledWith(1, expect.stringContaining('× unknown option \'--unknown\''))
-    expect(writeErrMock).toHaveBeenNthCalledWith(2, expect.stringContaining('\n💡 Run `lint-pilot lint --help` for more information.'))
+    expect(writeErrMock).toHaveBeenNthCalledWith(2, expect.stringContaining('\n💡 Run `yuna lint --help` for more information.'))
   })
 
   it('registers the lint command', () => {

--- a/src/commands/lint/__tests__/action.spec.ts
+++ b/src/commands/lint/__tests__/action.spec.ts
@@ -32,13 +32,13 @@ describe('lint action', () => {
     cache: false,
     clearCache: false,
     debug: false,
-    emoji: '✈️',
+    emoji: '🌸',
     eslintInclude: undefined,
     eslintUseLegacyConfig: false,
     fix: false,
     ignoreDirs: undefined,
     ignorePatterns: undefined,
-    title: 'Lint Pilot',
+    title: 'Yuna',
     watch: false,
   }
 
@@ -89,7 +89,7 @@ describe('lint action', () => {
 
       await action(supervisor, defaultOptions)
 
-      expect(colourLog.title).toHaveBeenCalledWith('✈️ Lint Pilot\n')
+      expect(colourLog.title).toHaveBeenCalledWith('🌸 Yuna\n')
     })
 
     it('logs a custom title and emoji', async () => {
@@ -155,7 +155,7 @@ describe('lint action', () => {
         eslintUseLegacyConfig: false,
         filePatterns: mockFilePatterns,
         fix: false,
-        title: 'Lint Pilot',
+        title: 'Yuna',
         watch: false,
       })
     })
@@ -175,7 +175,7 @@ describe('lint action', () => {
         eslintUseLegacyConfig: true,
         filePatterns: mockFilePatterns,
         fix: true,
-        title: 'Lint Pilot',
+        title: 'Yuna',
         watch: false,
       })
     })

--- a/src/commands/lint/__tests__/action.spec.ts
+++ b/src/commands/lint/__tests__/action.spec.ts
@@ -32,7 +32,7 @@ describe('lint action', () => {
     cache: false,
     clearCache: false,
     debug: false,
-    emoji: '🌸',
+    emoji: '🌺',
     eslintInclude: undefined,
     eslintUseLegacyConfig: false,
     fix: false,
@@ -89,7 +89,7 @@ describe('lint action', () => {
 
       await action(supervisor, defaultOptions)
 
-      expect(colourLog.title).toHaveBeenCalledWith('🌸 Yuna\n')
+      expect(colourLog.title).toHaveBeenCalledWith('🌺 Yuna\n')
     })
 
     it('logs a custom title and emoji', async () => {

--- a/src/commands/lint/__tests__/command.spec.ts
+++ b/src/commands/lint/__tests__/command.spec.ts
@@ -36,8 +36,8 @@ describe('lintCommand', () => {
     expect(action).toHaveBeenCalledWith(supervisor, expect.objectContaining({
       fix: false,
       watch: false,
-      emoji: '✈️',
-      title: 'Lint Pilot',
+      emoji: '🌸',
+      title: 'Yuna',
       cache: false,
       clearCache: false,
       debug: false,

--- a/src/commands/lint/__tests__/command.spec.ts
+++ b/src/commands/lint/__tests__/command.spec.ts
@@ -36,7 +36,7 @@ describe('lintCommand', () => {
     expect(action).toHaveBeenCalledWith(supervisor, expect.objectContaining({
       fix: false,
       watch: false,
-      emoji: '🌸',
+      emoji: '🌺',
       title: 'Yuna',
       cache: false,
       clearCache: false,

--- a/src/commands/lint/__tests__/execute-all.spec.ts
+++ b/src/commands/lint/__tests__/execute-all.spec.ts
@@ -24,7 +24,7 @@ describe('executeAllLinters', () => {
       ignorePatterns: ['**/node_modules/**'],
     },
     fix: false,
-    title: 'Lint Pilot',
+    title: 'Yuna',
     watch: false,
   }
 

--- a/src/commands/lint/command.ts
+++ b/src/commands/lint/command.ts
@@ -40,7 +40,7 @@ const command = (program: Command, supervisor: ProcessSupervisor) => {
     .option('-w, --watch', 'watch for file changes and re-run the linters', false)
 
     // Customisation Options
-    .option('-e, --emoji <string>', 'customise the emoji displayed when running yuna', '🌸')
+    .option('-e, --emoji <string>', 'customise the emoji displayed when running yuna', '🌺')
     .option('-t, --title <string>', 'customise the title displayed when running yuna', 'Yuna')
 
     // Caching Options

--- a/src/commands/lint/command.ts
+++ b/src/commands/lint/command.ts
@@ -7,27 +7,27 @@ import action from './action'
 const helpText = `
 Examples:
   Automatically fix problems:
-    ${chalk.gray('$ lint-pilot lint --fix')}
+    ${chalk.gray('$ yuna lint --fix')}
   Watch for file changes and re-run the linters:
-    ${chalk.gray('$ lint-pilot lint --watch')}
+    ${chalk.gray('$ yuna lint --watch')}
   Customise the emoji and title:
-    ${chalk.gray('$ lint-pilot lint -e 🚀 -t "Rocket Lint"')}
+    ${chalk.gray('$ yuna lint -e 🚀 -t "Rocket Lint"')}
   Enable caching for faster linting:
-    ${chalk.gray('$ lint-pilot lint --cache')}
+    ${chalk.gray('$ yuna lint --cache')}
   Clear the cache:
-    ${chalk.gray('$ lint-pilot lint --clear-cache')}
+    ${chalk.gray('$ yuna lint --clear-cache')}
   Ignore specific directories:
-    ${chalk.gray('$ lint-pilot lint --ignore-dirs generated')}
+    ${chalk.gray('$ yuna lint --ignore-dirs generated')}
   Ignore specific file patterns:
-    ${chalk.gray('$ lint-pilot lint --ignore-patterns "*.cjs"')}
+    ${chalk.gray('$ yuna lint --ignore-patterns "*.cjs"')}
   Include additional file patterns for ESLint:
-    ${chalk.gray('$ lint-pilot lint --eslint-include "**/*.mdx"')}
+    ${chalk.gray('$ yuna lint --eslint-include "**/*.mdx"')}
   Output debug information (e.g., configuration details, error stacks, file paths):
-    ${chalk.gray('$ lint-pilot lint --debug')}
+    ${chalk.gray('$ yuna lint --debug')}
   Use legacy ESLint config:
-    ${chalk.gray('$ lint-pilot lint --eslint-use-legacy-config')}
+    ${chalk.gray('$ yuna lint --eslint-use-legacy-config')}
   Run all linters with caching, fixing, and watching for changes:
-    ${chalk.gray('$ lint-pilot lint --cache --fix --watch')}`
+    ${chalk.gray('$ yuna lint --cache --fix --watch')}`
 
 const command = (program: Command, supervisor: ProcessSupervisor) => {
   program
@@ -40,8 +40,8 @@ const command = (program: Command, supervisor: ProcessSupervisor) => {
     .option('-w, --watch', 'watch for file changes and re-run the linters', false)
 
     // Customisation Options
-    .option('-e, --emoji <string>', 'customise the emoji displayed when running lint-pilot', '✈️')
-    .option('-t, --title <string>', 'customise the title displayed when running lint-pilot', 'Lint Pilot')
+    .option('-e, --emoji <string>', 'customise the emoji displayed when running yuna', '🌸')
+    .option('-t, --title <string>', 'customise the title displayed when running yuna', 'Yuna')
 
     // Caching Options
     .option('--cache', 'cache linting results', false)
@@ -60,7 +60,7 @@ const command = (program: Command, supervisor: ProcessSupervisor) => {
 
     .addHelpText('before', 'Command: lint')
     .addHelpText('after', helpText)
-    .showHelpAfterError(`\n💡 Run \`lint-pilot lint --help\` for more information.`)
+    .showHelpAfterError(`\n💡 Run \`yuna lint --help\` for more information.`)
 }
 
 export default command

--- a/src/program.ts
+++ b/src/program.ts
@@ -12,13 +12,13 @@ interface CreateProgramOptions {
 const helpText = `
 Examples:
   Run all linters (default command):
-    ${chalk.gray('$ lint-pilot')}
+    ${chalk.gray('$ yuna')}
   Run all linters (explicitly):
-    ${chalk.gray('$ lint-pilot lint')}
+    ${chalk.gray('$ yuna lint')}
   Automatically fix problems and watch for changes:
-    ${chalk.gray('$ lint-pilot --fix --watch')}
+    ${chalk.gray('$ yuna --fix --watch')}
   Enable caching for faster linting:
-    ${chalk.gray('$ lint-pilot --cache --fix --watch')}`
+    ${chalk.gray('$ yuna --cache --fix --watch')}`
 
 const createProgram = ({ supervisor }: CreateProgramOptions): Command => {
   const program = new Command()
@@ -28,7 +28,7 @@ const createProgram = ({ supervisor }: CreateProgramOptions): Command => {
     .description(description)
     .version(version)
 
-    .addHelpText('beforeAll', '\n✈️ Lint Pilot\n')
+    .addHelpText('beforeAll', '\n🌸 Yuna\n')
     .addHelpText('after', helpText)
     .configureOutput({
       outputError: (str, write) => write(chalk.red(`\n× ${str.replace(/^error: /i, '')}`)),

--- a/src/program.ts
+++ b/src/program.ts
@@ -28,7 +28,7 @@ const createProgram = ({ supervisor }: CreateProgramOptions): Command => {
     .description(description)
     .version(version)
 
-    .addHelpText('beforeAll', '\n🌸 Yuna\n')
+    .addHelpText('beforeAll', '\n🌺 Yuna\n')
     .addHelpText('after', helpText)
     .configureOutput({
       outputError: (str, write) => write(chalk.red(`\n× ${str.replace(/^error: /i, '')}`)),

--- a/src/utils/__tests__/colour-log.spec.ts
+++ b/src/utils/__tests__/colour-log.spec.ts
@@ -153,10 +153,10 @@ describe('colourLog', () => {
   describe('title', () => {
 
     it('logs the title in cyan', () => {
-      colourLog.title('🌸 Yuna')
+      colourLog.title('🌺 Yuna')
 
-      expect(chalk.cyan).toHaveBeenCalledOnceWith('🌸 Yuna')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('🌸 Yuna')
+      expect(chalk.cyan).toHaveBeenCalledOnceWith('🌺 Yuna')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('🌺 Yuna')
     })
 
   })

--- a/src/utils/__tests__/colour-log.spec.ts
+++ b/src/utils/__tests__/colour-log.spec.ts
@@ -153,10 +153,10 @@ describe('colourLog', () => {
   describe('title', () => {
 
     it('logs the title in cyan', () => {
-      colourLog.title('✈️ Lint Pilot ✈️')
+      colourLog.title('🌸 Yuna')
 
-      expect(chalk.cyan).toHaveBeenCalledOnceWith('✈️ Lint Pilot ✈️')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('✈️ Lint Pilot ✈️')
+      expect(chalk.cyan).toHaveBeenCalledOnceWith('🌸 Yuna')
+      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('🌸 Yuna')
     })
 
   })

--- a/src/utils/__tests__/notifier.spec.ts
+++ b/src/utils/__tests__/notifier.spec.ts
@@ -30,7 +30,7 @@ describe('notifyResults', () => {
       generateReport(0, 0),
       generateReport(1, 0),
       generateReport(0, 1),
-    ], 'Lint Pilot')
+    ], 'Yuna')
 
     expect(exitCode).toBe(1)
   })
@@ -40,7 +40,7 @@ describe('notifyResults', () => {
       generateReport(0, 0),
       generateReport(0, 0),
       generateReport(0, 1),
-    ], 'Lint Pilot')
+    ], 'Yuna')
 
     expect(exitCode).toBe(0)
   })
@@ -49,7 +49,7 @@ describe('notifyResults', () => {
     const exitCode = notifyResults([
       generateReport(0, 0),
       generateReport(0, 0),
-    ], 'Lint Pilot')
+    ], 'Yuna')
 
     expect(exitCode).toBe(0)
   })
@@ -59,12 +59,12 @@ describe('notifyResults', () => {
       generateReport(0, 0),
       generateReport(1, 1),
       generateReport(0, 1),
-    ], 'Lint Pilot')
+    ], 'Yuna')
 
     expect(notifier.notify).toHaveBeenCalledOnceWith({
       message: '1 error found. Please fix it before continuing.',
       sound: 'Frog',
-      title: '🚨 Lint Pilot',
+      title: '🚨 Yuna',
     })
   })
 
@@ -73,12 +73,12 @@ describe('notifyResults', () => {
       generateReport(0, 0),
       generateReport(5, 0),
       generateReport(2, 1),
-    ], 'Lint Pilot')
+    ], 'Yuna')
 
     expect(notifier.notify).toHaveBeenCalledOnceWith({
       message: '7 errors found. Please fix them before continuing.',
       sound: 'Frog',
-      title: '🚨 Lint Pilot',
+      title: '🚨 Yuna',
     })
   })
 
@@ -87,12 +87,12 @@ describe('notifyResults', () => {
       generateReport(0, 0),
       generateReport(0, 0),
       generateReport(0, 1),
-    ], 'Lint Pilot')
+    ], 'Yuna')
 
     expect(notifier.notify).toHaveBeenCalledOnceWith({
       message: '1 warning found. Please review before continuing.',
       sound: 'Frog',
-      title: '⚠️ Lint Pilot',
+      title: '⚠️ Yuna',
     })
   })
 
@@ -101,12 +101,12 @@ describe('notifyResults', () => {
       generateReport(0, 0),
       generateReport(0, 7),
       generateReport(0, 2),
-    ], 'Lint Pilot')
+    ], 'Yuna')
 
     expect(notifier.notify).toHaveBeenCalledOnceWith({
       message: '9 warnings found. Please review them before continuing.',
       sound: 'Frog',
-      title: '⚠️ Lint Pilot',
+      title: '⚠️ Yuna',
     })
   })
 
@@ -114,12 +114,12 @@ describe('notifyResults', () => {
     notifyResults([
       generateReport(0, 0),
       generateReport(0, 0),
-    ], 'Lint Pilot')
+    ], 'Yuna')
 
     expect(notifier.notify).toHaveBeenCalledOnceWith({
       message: 'All lint checks have passed. Your code is clean!',
       sound: 'Purr',
-      title: '✅ Lint Pilot',
+      title: '✅ Yuna',
     })
   })
 
@@ -131,7 +131,7 @@ describe('notifyResults', () => {
     const exitCode = notifyResults([
       generateReport(0, 0),
       generateReport(0, 0),
-    ], 'Lint Pilot')
+    ], 'Yuna')
 
     expect(exitCode).toBe(0)
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5560,59 +5560,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lint-pilot@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "lint-pilot@workspace:."
-  dependencies:
-    "@changesets/cli": "npm:2.29.8"
-    "@rollup/plugin-json": "npm:6.1.0"
-    "@rollup/plugin-node-resolve": "npm:16.0.3"
-    "@rollup/plugin-terser": "npm:0.4.4"
-    "@rollup/plugin-typescript": "npm:12.3.0"
-    "@stylistic/stylelint-plugin": "npm:3.0.1"
-    "@types/eslint": "npm:9.6.1"
-    "@types/jest": "npm:30.0.0"
-    "@types/markdownlint-rule-helpers": "npm:0.21.5"
-    "@types/node-notifier": "npm:8.0.5"
-    chalk: "npm:5.6.2"
-    chokidar: "npm:3.6.0"
-    commander: "npm:12.1.0"
-    eslint: "npm:9.10.0"
-    eslint-plugin-eslint-comments: "npm:3.2.0"
-    eslint-plugin-inclusive-language: "npm:2.2.1"
-    eslint-plugin-jest: "npm:28.8.3"
-    eslint-plugin-n: "npm:17.10.2"
-    eslint-plugin-promise: "npm:7.1.0"
-    eslint-plugin-sort-destructure-keys: "npm:2.0.0"
-    eslint-plugin-sort-exports: "npm:0.9.1"
-    glob: "npm:10.4.5"
-    jest: "npm:30.2.0"
-    knip: "npm:5.80.2"
-    markdownlint: "npm:0.35.0"
-    markdownlint-rule-helpers: "npm:0.26.0"
-    node-notifier: "npm:10.0.1"
-    postcss-less: "npm:6.0.0"
-    postcss-scss: "npm:4.0.9"
-    process-supervisor: "npm:1.0.0"
-    rimraf: "npm:5.0.10"
-    rollup: "npm:4.55.1"
-    rollup-plugin-copy: "npm:3.5.0"
-    space-log: "npm:2.0.0"
-    stylelint: "npm:16.9.0"
-    stylelint-config-property-sort-order-smacss: "npm:10.0.0"
-    stylelint-declaration-strict-value: "npm:1.10.6"
-    stylelint-order: "npm:6.0.4"
-    stylelint-scss: "npm:6.5.1"
-    ts-jest: "npm:29.4.6"
-    ts-node: "npm:10.9.2"
-    tslib: "npm:2.7.0"
-    tsx: "npm:4.19.0"
-    typescript: "npm:5.5.4"
-  bin:
-    lint-pilot: ./lib/index.js
-  languageName: unknown
-  linkType: soft
-
 "locate-path@npm:^5.0.0":
   version: 5.0.0
   resolution: "locate-path@npm:5.0.0"
@@ -8024,6 +7971,59 @@ __metadata:
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
   languageName: node
   linkType: hard
+
+"yunalint@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "yunalint@workspace:."
+  dependencies:
+    "@changesets/cli": "npm:2.29.8"
+    "@rollup/plugin-json": "npm:6.1.0"
+    "@rollup/plugin-node-resolve": "npm:16.0.3"
+    "@rollup/plugin-terser": "npm:0.4.4"
+    "@rollup/plugin-typescript": "npm:12.3.0"
+    "@stylistic/stylelint-plugin": "npm:3.0.1"
+    "@types/eslint": "npm:9.6.1"
+    "@types/jest": "npm:30.0.0"
+    "@types/markdownlint-rule-helpers": "npm:0.21.5"
+    "@types/node-notifier": "npm:8.0.5"
+    chalk: "npm:5.6.2"
+    chokidar: "npm:3.6.0"
+    commander: "npm:12.1.0"
+    eslint: "npm:9.10.0"
+    eslint-plugin-eslint-comments: "npm:3.2.0"
+    eslint-plugin-inclusive-language: "npm:2.2.1"
+    eslint-plugin-jest: "npm:28.8.3"
+    eslint-plugin-n: "npm:17.10.2"
+    eslint-plugin-promise: "npm:7.1.0"
+    eslint-plugin-sort-destructure-keys: "npm:2.0.0"
+    eslint-plugin-sort-exports: "npm:0.9.1"
+    glob: "npm:10.4.5"
+    jest: "npm:30.2.0"
+    knip: "npm:5.80.2"
+    markdownlint: "npm:0.35.0"
+    markdownlint-rule-helpers: "npm:0.26.0"
+    node-notifier: "npm:10.0.1"
+    postcss-less: "npm:6.0.0"
+    postcss-scss: "npm:4.0.9"
+    process-supervisor: "npm:1.0.0"
+    rimraf: "npm:5.0.10"
+    rollup: "npm:4.55.1"
+    rollup-plugin-copy: "npm:3.5.0"
+    space-log: "npm:2.0.0"
+    stylelint: "npm:16.9.0"
+    stylelint-config-property-sort-order-smacss: "npm:10.0.0"
+    stylelint-declaration-strict-value: "npm:1.10.6"
+    stylelint-order: "npm:6.0.4"
+    stylelint-scss: "npm:6.5.1"
+    ts-jest: "npm:29.4.6"
+    ts-node: "npm:10.9.2"
+    tslib: "npm:2.7.0"
+    tsx: "npm:4.19.0"
+    typescript: "npm:5.5.4"
+  bin:
+    yuna: ./lib/index.js
+  languageName: unknown
+  linkType: soft
 
 "zod@npm:^4.1.11":
   version: 4.3.5


### PR DESCRIPTION
## Details

### What have you changed?
<!-- List changes in past tense -->
- 🌸 Renamed the project from `lint-pilot` to `yunalint`, with the CLI command changed to `yuna`

### Why are you making these changes?
<!-- List reasons in present tense -->
- 🌸 This establishes a new identity for the project with a more distinctive name and visual identity. The package and repository name (`yunalint`) accurately reflects the project while keeping the CLI command short and memorable (`yuna`)
