### PR TITLE
Set npmMinimalAgeGate in .yarnrc.yml 🛡️

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        node-version: [18.18, 20.x, 22.x, 24.x, 26.x]
 
     steps:
     - name: Checkout repository

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,3 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d

--- a/TODO
+++ b/TODO
@@ -1,5 +1,8 @@
 # TODO
 
+- [ ] Integration tests
+  - [ ] Update .github/workflows/test.yml
+
 ## ESLint Rules
 
 - [ ] [eslint](https://github.com/eslint/eslint/tree/main)

--- a/package.json
+++ b/package.json
@@ -91,5 +91,5 @@
     "stylelint-scss"
   ],
   "license": "MIT",
-  "packageManager": "yarn@4.6.0+sha512.5383cc12567a95f1d668fbe762dfe0075c595b4bfff433be478dbbe24e05251a8e8c3eb992a986667c1d53b6c3a9c85b8398c35a960587fbd9fa3a0915406728"
+  "packageManager": "yarn@4.15.0+sha512.07ec708ac11e2eaa4ea2b04cfbb272812f7e74a753f1595eaef4486c663a98306a30cca3e6fc40f7a0b168dcfb3a2490b6a5e0501e20fb69cc36f563dd161c53"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@ampproject/remapping@npm:^2.2.0":


### PR DESCRIPTION
## Details

### What have you changed?
<!-- List changes in past tense -->
- 🛡️ Added `npmMinimalAgeGate: 7d` to `.yarnrc.yml` to prevent installing packages published within the last 7 days. Required updating the package manager version from Yarn 4.6.0 to Yarn 4.15.0

- 🧪 Updated the test workflow to explicitly test on Node 18.18 (the minimum supported version) and added Node 26.x to the test matrix

### Why are you making these changes?
<!-- List reasons in present tense -->
- 🛡️ This protects the project from supply chain attacks by preventing the installation of newly published packages that may be malicious or compromised

- 🧪 This ensures the project is tested against the exact minimum Node version specified in `package.json` (18.18.0) and the latest Node release, improving confidence in version compatibility
