### PR TITLE
Review utils for production readiness 🛠️

### DIFF
--- a/src/utils/__tests__/colour-log.spec.ts
+++ b/src/utils/__tests__/colour-log.spec.ts
@@ -16,7 +16,7 @@ jest.unmock('@Utils/colour-log')
 
 describe('colourLog', () => {
 
-  const mockedConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {})
+  const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => true)
 
   describe('config', () => {
 
@@ -25,7 +25,7 @@ describe('colourLog', () => {
 
       expect(chalk.magenta).toHaveBeenCalledOnceWith('setting:')
       expect(chalk.dim).toHaveBeenCalledOnceWith('foo')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('setting:', 'foo')
+      expect(mockConsoleLog).toHaveBeenCalledOnceWith('setting:', 'foo')
     })
 
     it('logs the key in magenta and the config array in dim', () => {
@@ -33,7 +33,7 @@ describe('colourLog', () => {
 
       expect(chalk.magenta).toHaveBeenCalledOnceWith('setting:')
       expect(chalk.dim).toHaveBeenCalledOnceWith('[foo, bar, baz]')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('setting:', '[foo, bar, baz]')
+      expect(mockConsoleLog).toHaveBeenCalledOnceWith('setting:', '[foo, bar, baz]')
     })
 
   })
@@ -46,7 +46,7 @@ describe('colourLog', () => {
       colourLog.configDebug('Debug message', 'config')
 
       expect(chalk.blue).not.toHaveBeenCalled()
-      expect(mockedConsoleLog).not.toHaveBeenCalled()
+      expect(mockConsoleLog).not.toHaveBeenCalled()
     })
 
     it('logs the message in blue and the config in default if global.debug is true', () => {
@@ -55,9 +55,9 @@ describe('colourLog', () => {
       colourLog.configDebug('Debug message', 'config')
 
       expect(chalk.blue).toHaveBeenCalledOnceWith('Debug message')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nDebug message')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, 'config')
+      expect(mockConsoleLog).toHaveBeenCalledTimes(2)
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(1, '\nDebug message')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(2, 'config')
     })
 
   })
@@ -65,20 +65,20 @@ describe('colourLog', () => {
   describe('error', () => {
 
     const error = new Error('Oops')
-    const mockedConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => true)
 
     it('logs the text in red', () => {
       colourLog.error('An error occurred')
 
       expect(chalk.red).toHaveBeenCalledOnceWith('\n× An error occurred.')
-      expect(mockedConsoleError).toHaveBeenCalledOnceWith('\n× An error occurred.')
+      expect(mockConsoleError).toHaveBeenCalledOnceWith('\n× An error occurred.')
     })
 
     it('logs the text with debug instructions if there is an error and global.debug is false', () => {
       colourLog.error('An error occurred', error)
 
       expect(chalk.red).toHaveBeenCalledOnceWith('\n× An error occurred. Run with --debug for more information.')
-      expect(mockedConsoleError).toHaveBeenCalledOnceWith('\n× An error occurred. Run with --debug for more information.')
+      expect(mockConsoleError).toHaveBeenCalledOnceWith('\n× An error occurred. Run with --debug for more information.')
     })
 
     it('logs the error if global.debug is true', () => {
@@ -86,9 +86,9 @@ describe('colourLog', () => {
 
       colourLog.error('An error occurred', error)
 
-      expect(mockedConsoleError).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleError).toHaveBeenNthCalledWith(1, '\n× An error occurred.')
-      expect(mockedConsoleError).toHaveBeenNthCalledWith(2, `\n${error.stack}`)
+      expect(mockConsoleError).toHaveBeenCalledTimes(2)
+      expect(mockConsoleError).toHaveBeenNthCalledWith(1, '\n× An error occurred.')
+      expect(mockConsoleError).toHaveBeenNthCalledWith(2, `\n${error.stack}`)
     })
 
     it('logs the error message if error is an Error without a stack', () => {
@@ -99,9 +99,9 @@ describe('colourLog', () => {
 
       colourLog.error('An error occurred', noStackError)
 
-      expect(mockedConsoleError).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleError).toHaveBeenNthCalledWith(1, '\n× An error occurred.')
-      expect(mockedConsoleError).toHaveBeenNthCalledWith(2, `\n${noStackError.message}`)
+      expect(mockConsoleError).toHaveBeenCalledTimes(2)
+      expect(mockConsoleError).toHaveBeenNthCalledWith(1, '\n× An error occurred.')
+      expect(mockConsoleError).toHaveBeenNthCalledWith(2, `\n${noStackError.message}`)
     })
 
     it('logs the error if error is a string', () => {
@@ -109,9 +109,9 @@ describe('colourLog', () => {
 
       colourLog.error('An error occurred', 'String error')
 
-      expect(mockedConsoleError).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleError).toHaveBeenNthCalledWith(1, '\n× An error occurred.')
-      expect(mockedConsoleError).toHaveBeenNthCalledWith(2, '\nString error')
+      expect(mockConsoleError).toHaveBeenCalledTimes(2)
+      expect(mockConsoleError).toHaveBeenNthCalledWith(1, '\n× An error occurred.')
+      expect(mockConsoleError).toHaveBeenNthCalledWith(2, '\nString error')
     })
 
     it('logs the error if error is a plain object', () => {
@@ -119,9 +119,9 @@ describe('colourLog', () => {
 
       colourLog.error('An error occurred', { foo: 'bar' })
 
-      expect(mockedConsoleError).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleError).toHaveBeenNthCalledWith(1, '\n× An error occurred.')
-      expect(mockedConsoleError).toHaveBeenNthCalledWith(2, `\n${JSON.stringify({ foo: 'bar' }, null, 2)}`)
+      expect(mockConsoleError).toHaveBeenCalledTimes(2)
+      expect(mockConsoleError).toHaveBeenNthCalledWith(1, '\n× An error occurred.')
+      expect(mockConsoleError).toHaveBeenNthCalledWith(2, `\n${JSON.stringify({ foo: 'bar' }, null, 2)}`)
     })
 
     it('logs a fallback message if error cannot be stringified', () => {
@@ -132,9 +132,9 @@ describe('colourLog', () => {
 
       colourLog.error('An error occurred', circular)
 
-      expect(mockedConsoleError).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleError).toHaveBeenNthCalledWith(1, '\n× An error occurred.')
-      expect(mockedConsoleError).toHaveBeenNthCalledWith(2, '\nUnable to stringify error')
+      expect(mockConsoleError).toHaveBeenCalledTimes(2)
+      expect(mockConsoleError).toHaveBeenNthCalledWith(1, '\n× An error occurred.')
+      expect(mockConsoleError).toHaveBeenNthCalledWith(2, '\nUnable to stringify error')
     })
 
   })
@@ -145,7 +145,7 @@ describe('colourLog', () => {
       colourLog.info('Starting lint...')
 
       expect(chalk.blue).toHaveBeenCalledOnceWith('Starting lint...')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('Starting lint...')
+      expect(mockConsoleLog).toHaveBeenCalledOnceWith('Starting lint...')
     })
 
   })
@@ -156,20 +156,20 @@ describe('colourLog', () => {
       colourLog.title('🌺 Yuna')
 
       expect(chalk.cyan).toHaveBeenCalledOnceWith('🌺 Yuna')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('🌺 Yuna')
+      expect(mockConsoleLog).toHaveBeenCalledOnceWith('🌺 Yuna')
     })
 
   })
 
   describe('warning', () => {
 
-    const mockedConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const mockConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => true)
 
     it('logs the text in yellow', () => {
       colourLog.warning('Be careful!')
 
       expect(chalk.yellow).toHaveBeenCalledOnceWith('Be careful!')
-      expect(mockedConsoleWarn).toHaveBeenCalledOnceWith('Be careful!')
+      expect(mockConsoleWarn).toHaveBeenCalledOnceWith('Be careful!')
     })
 
   })

--- a/src/utils/__tests__/format-result.spec.ts
+++ b/src/utils/__tests__/format-result.spec.ts
@@ -44,6 +44,15 @@ describe('formatResult', () => {
     })
   })
 
+  it('trims the message', () => {
+    const formattedResult = formatResult({
+      ...commonResult,
+      message: '  Test message  ',
+    })
+
+    expect(formattedResult).toStrictEqual(commonFormattedResult)
+  })
+
   it('formats a result without a column', () => {
     const formattedResult = formatResult({
       ...commonResult,
@@ -67,15 +76,6 @@ describe('formatResult', () => {
       ...commonFormattedResult,
       position: '0',
     })
-  })
-
-  it('trims the message', () => {
-    const formattedResult = formatResult({
-      ...commonResult,
-      message: '  Test message  ',
-    })
-
-    expect(formattedResult).toStrictEqual(commonFormattedResult)
   })
 
 })

--- a/src/utils/__tests__/notifier.spec.ts
+++ b/src/utils/__tests__/notifier.spec.ts
@@ -112,7 +112,7 @@ describe('notifyResults', () => {
   })
 
   it('does not throw if notifier fails', () => {
-    (notifier.notify as jest.Mock).mockImplementationOnce(() => {
+    jest.mocked(notifier.notify).mockImplementationOnce(() => {
       throw new Error('Notification failed')
     })
 

--- a/src/utils/__tests__/reporting.spec.ts
+++ b/src/utils/__tests__/reporting.spec.ts
@@ -26,7 +26,7 @@ jest.mock('chalk', () => ({
 
 jest.mock('space-log')
 
-describe('colourLog', () => {
+describe('reporting', () => {
 
   const mockedConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {})
 

--- a/src/utils/__tests__/reporting.spec.ts
+++ b/src/utils/__tests__/reporting.spec.ts
@@ -28,7 +28,7 @@ jest.mock('space-log')
 
 describe('reporting', () => {
 
-  const mockedConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {})
+  const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => true)
 
   const commonSummary: ReportSummary = {
     deprecatedRules: [],
@@ -40,7 +40,7 @@ describe('reporting', () => {
     warningCount: 0,
   }
 
-  describe('results', () => {
+  describe('logResults', () => {
 
     it('returns if there are no results', () => {
       logResults({
@@ -48,7 +48,7 @@ describe('reporting', () => {
         summary: commonSummary,
       })
 
-      expect(mockedConsoleLog).not.toHaveBeenCalled()
+      expect(mockConsoleLog).not.toHaveBeenCalled()
     })
 
     it('logs the results', () => {
@@ -72,12 +72,12 @@ describe('reporting', () => {
       })
 
       // Info
-      expect(chalk.blue).toHaveBeenCalledOnceWith('\nLogging eslint results:')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nLogging eslint results:')
+      expect(chalk.blue).toHaveBeenNthCalledWith(1, '\nLogging eslint results:')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(1, '\nLogging eslint results:')
 
       // File 1
       expect(chalk.underline).toHaveBeenNthCalledWith(1, 'CONTRIBUTING.md')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '\n_CONTRIBUTING.md_')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(2, '\n_CONTRIBUTING.md_')
       expect(spaceLog).toHaveBeenNthCalledWith(1, {
         columnKeys: ['severity', 'position', 'message', 'rule'],
         spaceSize: 2,
@@ -85,29 +85,30 @@ describe('reporting', () => {
 
       // File 2
       expect(chalk.underline).toHaveBeenNthCalledWith(2, 'README.md')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(3, '\n_README.md_')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(3, '\n_README.md_')
       expect(spaceLog).toHaveBeenNthCalledWith(2, {
         columnKeys: ['severity', 'position', 'message', 'rule'],
         spaceSize: 2,
       }, [commonResult, commonResult])
 
       // Log Count
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(3)
+      expect(chalk.blue).toHaveBeenCalledTimes(1)
       expect(chalk.underline).toHaveBeenCalledTimes(2)
+      expect(mockConsoleLog).toHaveBeenCalledTimes(3)
       expect(spaceLog).toHaveBeenCalledTimes(2)
     })
 
   })
 
-  describe('summary', () => {
+  describe('logSummary', () => {
 
     let startTime: number
 
     const expectResult = () => {
       expect(chalk.cyan).toHaveBeenCalledWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledWith('[1 file, 1000ms]')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\nFinished eslint', '[1 file, 1000ms]')
+      expect(mockConsoleLog).toHaveBeenCalledTimes(2)
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(1, '\nFinished eslint', '[1 file, 1000ms]')
     }
 
     beforeEach(() => {
@@ -121,7 +122,7 @@ describe('reporting', () => {
 
       expect(chalk.cyan).toHaveBeenCalledOnceWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledOnceWith('[1 file, 1000ms]')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\nFinished eslint', '[1 file, 1000ms]')
+      expect(mockConsoleLog).toHaveBeenCalledOnceWith('\nFinished eslint', '[1 file, 1000ms]')
     })
 
     it('logs the finished lint message along with the file count and duration (multiple files)', () => {
@@ -132,7 +133,7 @@ describe('reporting', () => {
 
       expect(chalk.cyan).toHaveBeenCalledOnceWith('Finished eslint')
       expect(chalk.yellow).toHaveBeenCalledOnceWith('[7 files, 1000ms]')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\nFinished eslint', '[7 files, 1000ms]')
+      expect(mockConsoleLog).toHaveBeenCalledOnceWith('\nFinished eslint', '[7 files, 1000ms]')
     })
 
     it('logs the error count in red (single error)', () => {
@@ -143,7 +144,7 @@ describe('reporting', () => {
 
       expectResult()
       expect(chalk.red).toHaveBeenCalledWith('  1 error')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  1 error')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(2, '  1 error')
     })
 
     it('logs the error count in red (multiple errors)', () => {
@@ -154,7 +155,7 @@ describe('reporting', () => {
 
       expectResult()
       expect(chalk.red).toHaveBeenCalledWith('  2 errors')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  2 errors')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(2, '  2 errors')
     })
 
     it('logs the error count in red with the fixable error count in dim', () => {
@@ -167,7 +168,7 @@ describe('reporting', () => {
       expectResult()
       expect(chalk.red).toHaveBeenCalledWith('  3 errors')
       expect(chalk.dim).toHaveBeenCalledWith(' (2 fixable)')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  3 errors (2 fixable)')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(2, '  3 errors (2 fixable)')
     })
 
     it('logs the warning count in yellow (single warning)', () => {
@@ -178,7 +179,7 @@ describe('reporting', () => {
 
       expectResult()
       expect(chalk.yellow).toHaveBeenCalledWith('  1 warning')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  1 warning')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(2, '  1 warning')
     })
 
     it('logs the warning count in yellow (multiple warnings)', () => {
@@ -189,7 +190,7 @@ describe('reporting', () => {
 
       expectResult()
       expect(chalk.yellow).toHaveBeenCalledWith('  5 warnings')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  5 warnings')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(2, '  5 warnings')
     })
 
     it('logs the warning count in yellow with the fixable warning count in dim', () => {
@@ -202,7 +203,7 @@ describe('reporting', () => {
       expectResult()
       expect(chalk.yellow).toHaveBeenCalledWith('  6 warnings')
       expect(chalk.dim).toHaveBeenCalledWith(' (3 fixable)')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  6 warnings (3 fixable)')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(2, '  6 warnings (3 fixable)')
     })
 
     it('logs the deprecated rule count in magenta and the list in dim (single deprecation)', () => {
@@ -214,7 +215,7 @@ describe('reporting', () => {
       expectResult()
       expect(chalk.magenta).toHaveBeenCalledWith('  1 deprecation')
       expect(chalk.dim).toHaveBeenCalledWith(' [foo]')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  1 deprecation [foo]')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(2, '  1 deprecation [foo]')
     })
 
     it('logs the deprecated rule count in magenta and the list alphabetised in dim (multiple deprecations)', () => {
@@ -226,7 +227,7 @@ describe('reporting', () => {
       expectResult()
       expect(chalk.magenta).toHaveBeenCalledWith('  3 deprecations')
       expect(chalk.dim).toHaveBeenCalledWith(' [bar, baz, foo]')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  3 deprecations [bar, baz, foo]')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(2, '  3 deprecations [bar, baz, foo]')
     })
 
     it('logs everything together', () => {
@@ -246,12 +247,12 @@ describe('reporting', () => {
       expect(chalk.dim).toHaveBeenCalledWith(' (2 fixable)')
       expect(chalk.magenta).toHaveBeenCalledWith('  3 deprecations')
       expect(chalk.dim).toHaveBeenCalledWith(' [bar, baz, foo]')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '  2 errors (1 fixable)\n  3 warnings (2 fixable)\n  3 deprecations [bar, baz, foo]')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(2, '  2 errors (1 fixable)\n  3 warnings (2 fixable)\n  3 deprecations [bar, baz, foo]')
     })
 
   })
 
-  describe('summaryBlock', () => {
+  describe('logSummaryBlock', () => {
 
     it('logs the error count in a red background', () => {
       logSummaryBlock({
@@ -260,7 +261,7 @@ describe('reporting', () => {
       })
 
       expect(chalk.bgRed.black).toHaveBeenCalledOnceWith(' 1 ESLint Error ')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n🚨  1 ESLint Error ')
+      expect(mockConsoleLog).toHaveBeenCalledOnceWith('\n🚨  1 ESLint Error ')
     })
 
     it('logs the warning count in a yellow background', () => {
@@ -270,7 +271,7 @@ describe('reporting', () => {
       })
 
       expect(chalk.bgYellow.black).toHaveBeenCalledOnceWith(' 1 ESLint Warning ')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n🚧  1 ESLint Warning ')
+      expect(mockConsoleLog).toHaveBeenCalledOnceWith('\n🚧  1 ESLint Warning ')
     })
 
     it('logs the both the error and warning counts if both are present', () => {
@@ -282,16 +283,16 @@ describe('reporting', () => {
 
       expect(chalk.bgRed.black).toHaveBeenCalledOnceWith(' 2 ESLint Errors ')
       expect(chalk.bgYellow.black).toHaveBeenCalledOnceWith(' 3 ESLint Warnings ')
-      expect(mockedConsoleLog).toHaveBeenCalledTimes(2)
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, '\n🚨  2 ESLint Errors ')
-      expect(mockedConsoleLog).toHaveBeenNthCalledWith(2, '\n🚧  3 ESLint Warnings ')
+      expect(mockConsoleLog).toHaveBeenCalledTimes(2)
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(1, '\n🚨  2 ESLint Errors ')
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(2, '\n🚧  3 ESLint Warnings ')
     })
 
     it('logs a success message if there are no errors or warnings', () => {
       logSummaryBlock(commonSummary)
 
       expect(chalk.bgGreen.black).toHaveBeenCalledOnceWith(' ESLint Success! ')
-      expect(mockedConsoleLog).toHaveBeenCalledOnceWith('\n✅  ESLint Success! ')
+      expect(mockConsoleLog).toHaveBeenCalledOnceWith('\n✅  ESLint Success! ')
     })
 
   })

--- a/src/utils/__tests__/source-files.spec.ts
+++ b/src/utils/__tests__/source-files.spec.ts
@@ -59,24 +59,24 @@ describe('sourceFiles', () => {
   it('returns a single file sourced for the file pattern', async () => {
     expect.assertions(3)
 
-    const mockedFiles = ['file1.ts']
+    const mockFiles = ['file1.ts']
 
-    jest.mocked(glob).mockResolvedValue(mockedFiles)
+    jest.mocked(glob).mockResolvedValue(mockFiles)
 
     const files = await sourceFiles(getFilePatterns(), Linter.ESLint)
 
     expect(glob).toHaveBeenCalledOnceWith(['**/*.ts'], { ignore: [ 'node_modules' ] })
-    expect(files).toStrictEqual(mockedFiles)
-    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Sourced 1 file for ESLint:', mockedFiles)
+    expect(files).toStrictEqual(mockFiles)
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Sourced 1 file for ESLint:', mockFiles)
   })
 
   it('returns multiple files sourced for the file pattern - excluding any duplicates', async () => {
     expect.assertions(3)
 
-    const mockedFiles = ['file1.ts', 'file2.ts', 'file1.ts']
+    const mockFiles = ['file1.ts', 'file2.ts', 'file1.ts']
     const expectedFiles = ['file1.ts', 'file2.ts']
 
-    jest.mocked(glob).mockResolvedValue(mockedFiles)
+    jest.mocked(glob).mockResolvedValue(mockFiles)
 
     const files = await sourceFiles(getFilePatterns(), Linter.ESLint)
 

--- a/src/utils/watch-files.ts
+++ b/src/utils/watch-files.ts
@@ -17,18 +17,17 @@ interface FileChangedEventPayload {
 
 const fileWatcherEvents = new EventEmitter()
 
-const fileHashes = new Map<string, string>()
-const pendingChanges = new Map<string, NodeJS.Timeout>()
-
-const cancelExistingTimeout = (path: string) => {
-  const existingTimeout = pendingChanges.get(path)
-  if (existingTimeout) {
-    clearTimeout(existingTimeout)
-    pendingChanges.delete(path)
-  }
-}
-
 const watchFiles = ({ ignorePatterns, includePatterns }: FilePatterns, linters?: Array<Linter>) => {
+  const fileHashes = new Map<string, string>()
+  const pendingChanges = new Map<string, NodeJS.Timeout>()
+
+  const cancelExistingTimeout = (path: string) => {
+    const existingTimeout = pendingChanges.get(path)
+    if (existingTimeout) {
+      clearTimeout(existingTimeout)
+      pendingChanges.delete(path)
+    }
+  }
   const filteredPatterns = linters
     ? linters.flatMap(linter => includePatterns[linter])
     : Object.values(includePatterns).flat()

--- a/src/utils/watch-files.ts
+++ b/src/utils/watch-files.ts
@@ -21,6 +21,10 @@ const watchFiles = ({ ignorePatterns, includePatterns }: FilePatterns, linters?:
   const fileHashes = new Map<string, string>()
   const pendingChanges = new Map<string, NodeJS.Timeout>()
 
+  const filteredPatterns = linters
+    ? linters.flatMap(linter => includePatterns[linter])
+    : Object.values(includePatterns).flat()
+
   const cancelExistingTimeout = (path: string) => {
     const existingTimeout = pendingChanges.get(path)
     if (existingTimeout) {
@@ -28,9 +32,6 @@ const watchFiles = ({ ignorePatterns, includePatterns }: FilePatterns, linters?:
       pendingChanges.delete(path)
     }
   }
-  const filteredPatterns = linters
-    ? linters.flatMap(linter => includePatterns[linter])
-    : Object.values(includePatterns).flat()
 
   const watcher = chokidar.watch(filteredPatterns, {
     ignored: ignorePatterns,


### PR DESCRIPTION
## Details

### What have you changed?
<!-- List changes in past tense -->
- 🏗️ Moved `fileHashes` and `pendingChanges` Maps inside the `watchFiles` function scope

- 🧪 Improved test consistency and quality across utility test files
  - Renamed test mock variables from `mocked*` to `mock*` prefix
  - Updated console mock implementations to return `true` instead of `undefined`
  - Fixed describe block name in `reporting.spec.ts` to match the module being tested
  - Reordered test cases and updated type assertions to use `jest.mocked()`

### Why are you making these changes?
<!-- List reasons in present tense -->
- 🏗️ This ensures the Maps are scoped to each watcher instance rather than being shared globally, preventing state leakage between multiple watchers

- 🧪 This establishes consistent testing patterns and improves test reliability across the codebase
  - The `mock*` prefix is more concise and aligns with common Jest conventions
  - Realistic console mock behaviour prevents potential issues with tests that check return values
  - Consistent naming and proper type safety reduce cognitive load and catch errors earlier
