### PR TITLE
Upgrade Stylelint ⬆️

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x, 26.x]
+        node-version: [20.19, 22.x, 24.x, 26.x]
 
     steps:
       - name: Checkout repository

--- a/config/stylelint.config.ts
+++ b/config/stylelint.config.ts
@@ -3,7 +3,9 @@ import postcssScss from 'postcss-scss'
 
 import Rules from './stylelint/rules'
 
-export default {
+import type { Config } from 'stylelint'
+
+const config: Config = {
   extends: [
     'stylelint-config-property-sort-order-smacss',
   ],
@@ -50,3 +52,5 @@ export default {
     ...Rules.Stylistic,
   },
 }
+
+export default config

--- a/config/stylelint.config.ts
+++ b/config/stylelint.config.ts
@@ -20,8 +20,8 @@ const config: Config = {
       'import-notation': 'string',
       'media-query-no-invalid': null,
       'no-invalid-position-at-import-rule': [true, {
-				ignoreAtRules: ['use', 'forward'],
-			}],
+        ignoreAtRules: ['use', 'forward'],
+      }],
       'property-no-unknown': null, // scss/property-no-unknown
       ...Rules.Scss,
     },
@@ -36,8 +36,8 @@ const config: Config = {
       'import-notation': 'string',
       'media-query-no-invalid': null,
       'no-invalid-position-at-import-rule': [true, {
-				ignoreAtRules: ['use', 'forward'],
-			}],
+        ignoreAtRules: ['use', 'forward'],
+      }],
     },
   }],
   plugins: [

--- a/config/stylelint.config.ts
+++ b/config/stylelint.config.ts
@@ -5,7 +5,7 @@ import Rules from './stylelint/rules'
 
 import type { Config } from 'stylelint'
 
-const config: Config = {
+export default {
   extends: [
     'stylelint-config-property-sort-order-smacss',
   ],
@@ -51,6 +51,4 @@ const config: Config = {
     ...Rules.Stylelint,
     ...Rules.Stylistic,
   },
-}
-
-export default config
+} satisfies Config

--- a/jest-config/setup.ts
+++ b/jest-config/setup.ts
@@ -11,6 +11,10 @@ jest.mock('markdownlint/promise', () => ({
   readConfig: jest.fn(),
 }))
 
+jest.mock('stylelint', () => ({
+  lint: jest.fn(),
+}))
+
 jest.mock('@Utils/colour-log')
 
 jest.spyOn(process, 'exit').mockImplementation(code => {

--- a/jest-config/setup.ts
+++ b/jest-config/setup.ts
@@ -12,8 +12,11 @@ jest.mock('markdownlint/promise', () => ({
 }))
 
 jest.mock('stylelint', () => ({
-  lint: jest.fn(),
-  resolveConfig: jest.fn(),
+  __esModule: true,
+  default: {
+    lint: jest.fn(),
+    resolveConfig: jest.fn(),
+  },
 }))
 
 jest.mock('@Utils/colour-log')

--- a/jest-config/setup.ts
+++ b/jest-config/setup.ts
@@ -13,6 +13,7 @@ jest.mock('markdownlint/promise', () => ({
 
 jest.mock('stylelint', () => ({
   lint: jest.fn(),
+  resolveConfig: jest.fn(),
 }))
 
 jest.mock('@Utils/colour-log')

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -27,6 +27,15 @@ const config: Config = {
   testEnvironment: 'node',
   transform: {
     '^.+\\.(j|t)s$': ['ts-jest', {
+      astTransformers: {
+        before: [{
+          path: 'ts-jest-mock-import-meta',
+          options: { metaObjectReplacement: { url: `file://${process.cwd()}/config/stylint.config.js` } }
+        }],
+      },
+      diagnostics: {
+        ignoreCodes: [1343]
+      },
       tsconfig: {
         rootDir: '.',
       },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -30,7 +30,7 @@ const config: Config = {
       astTransformers: {
         before: [{
           path: 'ts-jest-mock-import-meta',
-          options: { metaObjectReplacement: { url: `file://${process.cwd()}/config/stylint.config.js` } }
+          options: { metaObjectReplacement: { url: `file://${process.cwd()}/config/stylelint.config.ts` } }
         }],
       },
       diagnostics: {

--- a/knip.json
+++ b/knip.json
@@ -7,12 +7,16 @@
     "stylelint-declaration-strict-value",
     "stylelint-order",
     "stylelint-scss",
+    "ts-jest-mock-import-meta",
     "ts-node"
+  ],
+  "ignoreUnresolved": [
+    "./stylelint.config"
   ],
   "entry": [
     "config/all-legacy.ts",
     "config/all.ts",
-    "config/stylelint.config.js",
+    "config/stylelint.config.ts",
     "src/index.ts"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "rollup": "4.55.1",
     "rollup-plugin-copy": "3.5.0",
     "ts-jest": "29.4.11",
+    "ts-jest-mock-import-meta": "1.3.2",
     "ts-node": "10.9.2",
     "tslib": "2.7.0",
     "tsx": "4.19.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=20.19"
   },
   "bin": {
     "yuna": "./lib/index.js"
@@ -43,7 +43,7 @@
     "postcss-scss": "4.0.9",
     "process-supervisor": "1.0.0",
     "space-log": "2.0.0",
-    "stylelint": "16.9.0",
+    "stylelint": "17.12.0",
     "stylelint-config-property-sort-order-smacss": "10.0.0",
     "stylelint-declaration-strict-value": "1.10.6",
     "stylelint-order": "6.0.4",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/eslint": "9.6.1",
     "@types/jest": "30.0.0",
     "@types/node-notifier": "8.0.5",
+    "@types/postcss-less": "4.0.7",
     "jest": "30.4.2",
     "knip": "5.80.2",
     "rimraf": "5.0.10",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -59,5 +59,5 @@ export default defineConfig([{
 },
   createConfig('config/all-legacy.ts', 'cjs'),
   createConfig('config/all.ts', 'esm'),
-  createConfig('config/stylelint.config.js', 'cjs'),
+  createConfig('config/stylelint.config.ts', 'cjs'),
 ])

--- a/src/commands/lint/__tests__/action.spec.ts
+++ b/src/commands/lint/__tests__/action.spec.ts
@@ -33,7 +33,7 @@ describe('lint action', () => {
 
   describe('debug mode', () => {
 
-    it('sets global.debug to true when debug option is true', async () => {
+    it('sets `global.debug` to true when `debug` is true', async () => {
       expect.assertions(1)
 
       await lintAction(supervisor, { ...defaultLintCommandOptions, debug: true })
@@ -41,7 +41,7 @@ describe('lint action', () => {
       expect(global.debug).toBe(true)
     })
 
-    it('sets global.debug to false when debug option is false', async () => {
+    it('sets `global.debug` to false when `debug` is false', async () => {
       expect.assertions(1)
 
       await lintAction(supervisor, { ...defaultLintCommandOptions, debug: false })
@@ -89,7 +89,7 @@ describe('lint action', () => {
       expect(clearCacheDirectory).not.toHaveBeenCalled()
     })
 
-    it('clears cache when clearCache option is true', async () => {
+    it('clears cache when `clearCache` is true', async () => {
       expect.assertions(1)
 
       await lintAction(supervisor, { ...defaultLintCommandOptions, clearCache: true })
@@ -169,7 +169,7 @@ describe('lint action', () => {
       expect(watchFiles).not.toHaveBeenCalled()
     })
 
-    it('starts watcher when watch option is true', async () => {
+    it('starts watcher when `watch` is true', async () => {
       expect.assertions(1)
 
       await lintAction(supervisor, { ...defaultLintCommandOptions, watch: true })

--- a/src/commands/lint/__tests__/execute-all.spec.ts
+++ b/src/commands/lint/__tests__/execute-all.spec.ts
@@ -33,7 +33,7 @@ describe('executeAllLinters', () => {
     jest.spyOn(process, 'exit').mockImplementation()
   })
 
-  it('calls executeLinter for all three linters in parallel', async () => {
+  it('calls `executeLinter` for all three linters in parallel', async () => {
     expect.assertions(4)
 
     const expectedCommonArgs = {
@@ -81,7 +81,7 @@ describe('executeAllLinters', () => {
     expect(notifyResults).toHaveBeenCalledWith(mockReports, commonOptions.title)
   })
 
-  it('exits with code from notifyResults when not watching', async () => {
+  it('exits with code from `notifyResults` when not watching', async () => {
     expect.assertions(2)
 
     await executeAllLinters(commonOptions)
@@ -90,7 +90,7 @@ describe('executeAllLinters', () => {
     expect(process.exit).toHaveBeenCalledWith(0)
   })
 
-  it('logs "Watching for changes..." when watch is true', async () => {
+  it('logs "Watching for changes..." when `watch` is true', async () => {
     expect.assertions(2)
 
     await executeAllLinters({ ...commonOptions, watch: true })

--- a/src/linters/eslint/__tests__/lint-files.spec.ts
+++ b/src/linters/eslint/__tests__/lint-files.spec.ts
@@ -23,7 +23,7 @@ describe('lintFiles', () => {
     fix: false,
   }
 
-  const mockedLintResults: Array<ESLint.LintResult> = [{
+  const mockLintResults: Array<ESLint.LintResult> = [{
     errorCount: 0,
     fatalErrorCount: 0,
     filePath: path.join(process.cwd(), 'index.ts'),
@@ -35,16 +35,16 @@ describe('lintFiles', () => {
     warningCount: 0,
   }]
 
-  const lintFilesMock = jest.mocked(ESLint.prototype.lintFiles).mockImplementation(async () => mockedLintResults)
-  const loadESLintMock = jest.mocked(loadESLint).mockResolvedValue(ESLint)
-  const outputFixesMock = jest.mocked(ESLint.outputFixes)
+  const mockESLintFiles = jest.mocked(ESLint.prototype.lintFiles).mockImplementation(async () => mockLintResults)
+  const mockLoadESLint = jest.mocked(loadESLint).mockResolvedValue(ESLint)
+  const mockOutputFixes = jest.mocked(ESLint.outputFixes)
 
   it('creates a new ESLint instance using flat config by default', async () => {
     expect.assertions(1)
 
     await lintFiles(commonLintOptions)
 
-    expect(loadESLintMock).toHaveBeenCalledOnceWith({
+    expect(mockLoadESLint).toHaveBeenCalledOnceWith({
       useFlatConfig: true,
     })
   })
@@ -57,7 +57,7 @@ describe('lintFiles', () => {
       eslintUseLegacyConfig: false,
     })
 
-    expect(loadESLintMock).toHaveBeenCalledOnceWith({
+    expect(mockLoadESLint).toHaveBeenCalledOnceWith({
       useFlatConfig: true,
     })
   })
@@ -70,7 +70,7 @@ describe('lintFiles', () => {
       eslintUseLegacyConfig: true,
     })
 
-    expect(loadESLintMock).toHaveBeenCalledOnceWith({
+    expect(mockLoadESLint).toHaveBeenCalledOnceWith({
       useFlatConfig: false,
     })
   })
@@ -84,7 +84,7 @@ describe('lintFiles', () => {
     })
 
     expect(ESLint).toHaveBeenCalledOnceWith(commonESLintOptions)
-    expect(lintFilesMock).toHaveBeenCalledOnceWith(['index.ts'])
+    expect(mockESLintFiles).toHaveBeenCalledOnceWith(['index.ts'])
   })
 
   it('lints files with caching enabled when `cache` is true', async () => {
@@ -100,7 +100,7 @@ describe('lintFiles', () => {
       cache: true,
       cacheLocation: expect.stringContaining('.cache/lint/eslint'),
     })
-    expect(lintFilesMock).toHaveBeenCalledOnceWith(['index.ts'])
+    expect(mockESLintFiles).toHaveBeenCalledOnceWith(['index.ts'])
   })
 
   it('lints files with fix disabled when `fix` is false', async () => {
@@ -112,8 +112,8 @@ describe('lintFiles', () => {
     })
 
     expect(ESLint).toHaveBeenCalledOnceWith(commonESLintOptions)
-    expect(lintFilesMock).toHaveBeenCalledOnceWith(['index.ts'])
-    expect(outputFixesMock).not.toHaveBeenCalled()
+    expect(mockESLintFiles).toHaveBeenCalledOnceWith(['index.ts'])
+    expect(mockOutputFixes).not.toHaveBeenCalled()
   })
 
   it('lints files with fix enabled when `fix` is true', async () => {
@@ -128,8 +128,8 @@ describe('lintFiles', () => {
       ...commonESLintOptions,
       fix: true,
     })
-    expect(lintFilesMock).toHaveBeenCalledOnceWith(['index.ts'])
-    expect(outputFixesMock).toHaveBeenCalledOnceWith(mockedLintResults)
+    expect(mockESLintFiles).toHaveBeenCalledOnceWith(['index.ts'])
+    expect(mockOutputFixes).toHaveBeenCalledOnceWith(mockLintResults)
   })
 
   it('returns a report when ESLint successfully lints', async () => {
@@ -138,7 +138,7 @@ describe('lintFiles', () => {
     const result = await lintFiles(commonLintOptions)
 
     expect(ESLint).toHaveBeenCalledOnceWith(commonESLintOptions)
-    expect(lintFilesMock).toHaveBeenCalledOnceWith(['index.ts'])
+    expect(mockESLintFiles).toHaveBeenCalledOnceWith(['index.ts'])
     expect(result).toStrictEqual({
       results: {},
       summary: {
@@ -154,9 +154,9 @@ describe('lintFiles', () => {
   })
 
   test.each([
-    ['loadESLint', loadESLintMock],
-    ['lintFiles', lintFilesMock],
-    ['outputFixes', outputFixesMock],
+    ['loadESLint', mockLoadESLint],
+    ['lintFiles', mockESLintFiles],
+    ['outputFixes', mockOutputFixes],
   ])('exits the process when `%s` throws an error', async (_name, mock) => {
     expect.assertions(2)
 

--- a/src/linters/eslint/__tests__/lint-files.spec.ts
+++ b/src/linters/eslint/__tests__/lint-files.spec.ts
@@ -75,7 +75,7 @@ describe('lintFiles', () => {
     })
   })
 
-  it('lints files with cacheing disabled when `cache` is false', async () => {
+  it('lints files with caching disabled when `cache` is false', async () => {
     expect.assertions(2)
 
     await lintFiles({
@@ -87,7 +87,7 @@ describe('lintFiles', () => {
     expect(lintFilesMock).toHaveBeenCalledOnceWith(['index.ts'])
   })
 
-  it('lints files with cacheing enabled when `cache` is true', async () => {
+  it('lints files with caching enabled when `cache` is true', async () => {
     expect.assertions(2)
 
     await lintFiles({

--- a/src/linters/eslint/__tests__/process-results.spec.ts
+++ b/src/linters/eslint/__tests__/process-results.spec.ts
@@ -8,7 +8,7 @@ import type { ESLint, Linter } from 'eslint'
 
 describe('processResults', () => {
 
-  const commonResult: ESLint.LintResult = {
+  const commonLintResult: ESLint.LintResult = {
     errorCount: 0,
     fatalErrorCount: 0,
     filePath: path.join(process.cwd(), 'file.js'),
@@ -47,7 +47,7 @@ describe('processResults', () => {
 
   it('normalises file paths relative to the cwd', () => {
     const report = processResults([{
-      ...commonResult,
+      ...commonLintResult,
       filePath: path.join(process.cwd(), 'file.js'),
       messages: [commonMessage],
     }])
@@ -64,11 +64,11 @@ describe('processResults', () => {
 
   it('does not report results for files which have no messages', () => {
     const report = processResults([{
-      ...commonResult,
+      ...commonLintResult,
       filePath: path.join(process.cwd(), 'file.js'),
       messages: [commonMessage],
     }, {
-      ...commonResult,
+      ...commonLintResult,
       filePath: path.join(process.cwd(), 'file-2.js'),
       messages: [],
     }])
@@ -85,7 +85,7 @@ describe('processResults', () => {
 
   it('aggregates error and warning counts', () => {
     const report = processResults([{
-      ...commonResult,
+      ...commonLintResult,
       errorCount: 2,
       filePath: path.join(process.cwd(), 'file.js'),
       fixableErrorCount: 1,
@@ -93,7 +93,7 @@ describe('processResults', () => {
       messages: [commonMessage],
       warningCount: 3,
     }, {
-      ...commonResult,
+      ...commonLintResult,
       errorCount: 1,
       filePath: path.join(process.cwd(), 'file-2.js'),
       fixableErrorCount: 0,
@@ -121,7 +121,7 @@ describe('processResults', () => {
 
   it('formats warning messages', () => {
     const report = processResults([{
-      ...commonResult,
+      ...commonLintResult,
       filePath: path.join(process.cwd(), 'file.js'),
       messages: [{
         column: 2,
@@ -155,9 +155,81 @@ describe('processResults', () => {
     })
   })
 
+  it('formats error messages', () => {
+    const report = processResults([{
+      ...commonLintResult,
+      errorCount: 1,
+      filePath: path.join(process.cwd(), 'file.js'),
+      messages: [{
+        column: 10,
+        line: 8,
+        message: 'Test error',
+        ruleId: 'test-error',
+        severity: 2,
+      }],
+    }])
+
+    expect(report).toStrictEqual({
+      results: {
+        'file.js': [{
+          ...expectedResultThemes,
+          position: '8:10',
+          message: 'Test error',
+          rule: 'test-error',
+          severity: '  ×',
+        }],
+      },
+      summary: {
+        deprecatedRules: [],
+        errorCount: 1,
+        fileCount: 1,
+        fixableErrorCount: 0,
+        fixableWarningCount: 0,
+        linter: 'ESLint',
+        warningCount: 0,
+      },
+    })
+  })
+
+  it('formats errors with no ruleId as "core-error"', () => {
+    const report = processResults([{
+      ...commonLintResult,
+      errorCount: 1,
+      filePath: path.join(process.cwd(), 'file.js'),
+      messages: [{
+        column: 1,
+        line: 1,
+        message: 'Unknown error',
+        ruleId: null,
+        severity: 2,
+      }],
+    }])
+
+    expect(report).toStrictEqual({
+      results: {
+        'file.js': [{
+          ...expectedResultThemes,
+          position: '1:1',
+          message: 'Unknown error',
+          rule: 'core-error',
+          severity: '  ×',
+        }],
+      },
+      summary: {
+        deprecatedRules: [],
+        errorCount: 1,
+        fileCount: 1,
+        fixableErrorCount: 0,
+        fixableWarningCount: 0,
+        linter: 'ESLint',
+        warningCount: 0,
+      },
+    })
+  })
+
   it('formats multiple messages for a single file', () => {
     const report = processResults([{
-      ...commonResult,
+      ...commonLintResult,
       errorCount: 2,
       filePath: path.join(process.cwd(), 'file.js'),
       messages: [{
@@ -228,81 +300,9 @@ describe('processResults', () => {
     })
   })
 
-  it('formats error messages', () => {
-    const report = processResults([{
-      ...commonResult,
-      errorCount: 1,
-      filePath: path.join(process.cwd(), 'file.js'),
-      messages: [{
-        column: 10,
-        line: 8,
-        message: 'Test error',
-        ruleId: 'test-error',
-        severity: 2,
-      }],
-    }])
-
-    expect(report).toStrictEqual({
-      results: {
-        'file.js': [{
-          ...expectedResultThemes,
-          position: '8:10',
-          message: 'Test error',
-          rule: 'test-error',
-          severity: '  ×',
-        }],
-      },
-      summary: {
-        deprecatedRules: [],
-        errorCount: 1,
-        fileCount: 1,
-        fixableErrorCount: 0,
-        fixableWarningCount: 0,
-        linter: 'ESLint',
-        warningCount: 0,
-      },
-    })
-  })
-
-  it('formats errors with no ruleId as "core-error"', () => {
-    const report = processResults([{
-      ...commonResult,
-      errorCount: 1,
-      filePath: path.join(process.cwd(), 'file.js'),
-      messages: [{
-        column: 1,
-        line: 1,
-        message: 'Unknown error',
-        ruleId: null,
-        severity: 2,
-      }],
-    }])
-
-    expect(report).toStrictEqual({
-      results: {
-        'file.js': [{
-          ...expectedResultThemes,
-          position: '1:1',
-          message: 'Unknown error',
-          rule: 'core-error',
-          severity: '  ×',
-        }],
-      },
-      summary: {
-        deprecatedRules: [],
-        errorCount: 1,
-        fileCount: 1,
-        fixableErrorCount: 0,
-        fixableWarningCount: 0,
-        linter: 'ESLint',
-        warningCount: 0,
-      },
-    })
-  })
-
   it('accumulates deprecated rules without duplicates', () => {
     const report = processResults([{
-      ...commonResult,
+      ...commonLintResult,
       filePath: path.join(process.cwd(), 'file.js'),
       messages: [commonMessage],
       usedDeprecatedRules: [{
@@ -313,7 +313,7 @@ describe('processResults', () => {
         ruleId: 'deprecated-rule-2',
       }],
     }, {
-      ...commonResult,
+      ...commonLintResult,
       filePath: path.join(process.cwd(), 'file-2.js'),
       messages: [commonMessage],
       usedDeprecatedRules: [{

--- a/src/linters/eslint/lint-files.ts
+++ b/src/linters/eslint/lint-files.ts
@@ -22,13 +22,13 @@ const lintFiles = async ({ cache, eslintUseLegacyConfig, files, fix }: LintFiles
       fix,
     }).lintFiles(files)
 
-    // Process results
-    const report = processResults(results)
-
     // Fix files if requested
     if (fix) {
       await ESLint.outputFixes(results)
     }
+
+    // Process results
+    const report = processResults(results)
 
     // Return report
     return report

--- a/src/linters/markdownlint/__tests__/fix-file.spec.ts
+++ b/src/linters/markdownlint/__tests__/fix-file.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
 
 import { applyFixes } from 'markdownlint'
 
@@ -28,9 +29,9 @@ describe('fixFile', () => {
 
     fixFile({ errors, file: filePath })
 
-    expect(readFileSync).toHaveBeenCalledWith(`${process.cwd()}/${filePath}`, 'utf8')
+    expect(readFileSync).toHaveBeenCalledWith(path.join(process.cwd(), filePath), 'utf8')
     expect(applyFixes).toHaveBeenCalledWith(originalFileContent, errors)
-    expect(writeFileSync).toHaveBeenCalledWith(`${process.cwd()}/${filePath}`, fixedFileContent)
+    expect(writeFileSync).toHaveBeenCalledWith(path.join(process.cwd(), filePath), fixedFileContent)
   })
 
 })

--- a/src/linters/markdownlint/__tests__/lint-files.spec.ts
+++ b/src/linters/markdownlint/__tests__/lint-files.spec.ts
@@ -28,7 +28,7 @@ describe('lintFiles', () => {
   const mockLoadConfig = jest.mocked(loadConfig).mockResolvedValue({ default: true })
 
   it('lints files once when `fix` is false', async () => {
-    expect.assertions(3)
+    expect.assertions(2)
 
     await lintFiles({
       ...commonLintOptions,
@@ -36,8 +36,7 @@ describe('lintFiles', () => {
     })
 
     expect(mockLoadConfig).toHaveBeenCalledTimes(1)
-    expect(mockLint).toHaveBeenCalledTimes(1)
-    expect(mockLint).toHaveBeenNthCalledWith(1, commonMarkdownlintOptions)
+    expect(mockLint).toHaveBeenCalledOnceWith(commonMarkdownlintOptions)
   })
 
   test.each([
@@ -45,7 +44,7 @@ describe('lintFiles', () => {
     ['no errors are found', { 'README.md': [] }],
     ['no errors are fixable', { 'README.md': [markdownlintError] }],
   ])('lints files once when `fix` is true but %s', async (_title, mockReturnValue) => {
-    expect.assertions(3)
+    expect.assertions(2)
 
     mockLint.mockResolvedValueOnce(mockReturnValue)
 
@@ -55,8 +54,7 @@ describe('lintFiles', () => {
     })
 
     expect(mockLoadConfig).toHaveBeenCalledTimes(1)
-    expect(mockLint).toHaveBeenCalledTimes(1)
-    expect(mockLint).toHaveBeenNthCalledWith(1, commonMarkdownlintOptions)
+    expect(mockLint).toHaveBeenCalledOnceWith(commonMarkdownlintOptions)
   })
 
   it('lints files twice when `fix` is true and errors are fixable', async () => {

--- a/src/linters/markdownlint/__tests__/load-config.spec.ts
+++ b/src/linters/markdownlint/__tests__/load-config.spec.ts
@@ -15,14 +15,16 @@ describe('loadConfig', () => {
   it('returns the custom config if it exists', async () => {
     expect.assertions(3)
 
+    const customConfig = { default: true }
+
     jest.mocked(fs.existsSync).mockReturnValueOnce(true)
-    jest.mocked(readConfig).mockResolvedValue({ default: true })
+    jest.mocked(readConfig).mockResolvedValue(customConfig)
 
     const config = await loadConfig()
 
-    expect(readConfig).toHaveBeenCalledWith(path.join(process.cwd(), '.markdownlint.json'))
-    expect(colourLog.configDebug).toHaveBeenCalledWith('Using custom Markdownlint config:', { default: true })
-    expect(config).toStrictEqual({ default: true })
+    expect(readConfig).toHaveBeenCalledOnceWith(path.join(process.cwd(), '.markdownlint.json'))
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using custom Markdownlint config:', customConfig)
+    expect(config).toStrictEqual(customConfig)
   })
 
   it('returns the default config if no custom config exists', async () => {
@@ -33,7 +35,7 @@ describe('loadConfig', () => {
     const config = await loadConfig()
 
     expect(readConfig).not.toHaveBeenCalled()
-    expect(colourLog.configDebug).toHaveBeenCalledWith('Using default Markdownlint config:', expect.objectContaining(defaultConfig))
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using default Markdownlint config:', expect.objectContaining(defaultConfig))
     expect(config).toStrictEqual(expect.objectContaining(defaultConfig))
   })
 

--- a/src/linters/markdownlint/__tests__/process-results.spec.ts
+++ b/src/linters/markdownlint/__tests__/process-results.spec.ts
@@ -201,7 +201,7 @@ describe('processResults', () => {
     })
   })
 
-  it('sorts results by lineNumber and then by rule name', () => {
+  it('sorts results by line number and then by rule name', () => {
     const lintResults: LintResults = {
       'file.md': [{
         ...markdownlintError,
@@ -264,7 +264,7 @@ describe('processResults', () => {
     })
   })
 
-  it('sorts results by lineNumber and then by rule name when rules only have one name', () => {
+  it('sorts results by line number and then by rule name when rules only have one name', () => {
     const lintResults: LintResults = {
       'file.md': [{
         ...markdownlintError,

--- a/src/linters/markdownlint/__tests__/process-results.spec.ts
+++ b/src/linters/markdownlint/__tests__/process-results.spec.ts
@@ -7,7 +7,7 @@ import type { FormattedResult } from '@Types/lint'
 
 describe('processResults', () => {
 
-  const commonResult: FormattedResult = {
+  const commonFormattedResult: FormattedResult = {
     ...expectedResultThemes,
     position: '1:1',
     message: 'test-rule-description: test-error-detail',
@@ -48,10 +48,10 @@ describe('processResults', () => {
     })
   })
 
-  it('aggregates error counts', () => {
+  it('aggregates error and warning counts', () => {
     const report = processResults({
-      'file.md': [markdownlintError, fixableMarkdownlintError],
-      'file-2.md': [markdownlintError],
+      'file.md': [markdownlintError, fixableMarkdownlintError, { ...fixableMarkdownlintError, severity: 'warning' }],
+      'file-2.md': [markdownlintError, { ...markdownlintError, severity: 'warning' }],
       'file-3.md': [],
     })
 
@@ -65,9 +65,36 @@ describe('processResults', () => {
         errorCount: 3,
         fileCount: 3,
         fixableErrorCount: 1,
+        fixableWarningCount: 1,
+        linter: 'Markdownlint',
+        warningCount: 2,
+      },
+    })
+  })
+
+  it('formats warning messages', () => {
+    const report = processResults({
+      'file.md': [{
+        ...markdownlintError,
+        severity: 'warning',
+      }],
+    })
+
+    expect(report).toStrictEqual({
+      results: {
+        'file.md': [{
+          ...commonFormattedResult,
+          severity: '  ⚠',
+        }],
+      },
+      summary: {
+        deprecatedRules: [],
+        errorCount: 0,
+        fileCount: 1,
+        fixableErrorCount: 0,
         fixableWarningCount: 0,
         linter: 'Markdownlint',
-        warningCount: 0,
+        warningCount: 1,
       },
     })
   })
@@ -79,7 +106,7 @@ describe('processResults', () => {
 
     expect(report).toStrictEqual({
       results: {
-        'file.md': [commonResult],
+        'file.md': [commonFormattedResult],
       },
       summary: {
         deprecatedRules: [],
@@ -104,7 +131,7 @@ describe('processResults', () => {
     expect(report).toStrictEqual({
       results: {
         'file.md': [{
-          ...commonResult,
+          ...commonFormattedResult,
           position: '1',
         }],
       },
@@ -131,7 +158,7 @@ describe('processResults', () => {
     expect(report).toStrictEqual({
       results: {
         'file.md': [{
-          ...commonResult,
+          ...commonFormattedResult,
           message: 'test-rule-description',
         }],
       },
@@ -158,7 +185,7 @@ describe('processResults', () => {
     expect(report).toStrictEqual({
       results: {
         'file.md': [{
-          ...commonResult,
+          ...commonFormattedResult,
           rule: 'MD000',
         }],
       },
@@ -204,23 +231,23 @@ describe('processResults', () => {
     expect(report).toStrictEqual({
       results: {
         'file.md': [{
-          ...commonResult,
+          ...commonFormattedResult,
           position: '1:1',
           rule: 'test-rule-a',
         }, {
-          ...commonResult,
+          ...commonFormattedResult,
           position: '3:1',
           rule: 'test-rule-b',
         }, {
-          ...commonResult,
+          ...commonFormattedResult,
           position: '3:1',
           rule: 'test-rule-c',
         }, {
-          ...commonResult,
+          ...commonFormattedResult,
           position: '3:1',
           rule: 'test-rule-d',
         }, {
-          ...commonResult,
+          ...commonFormattedResult,
           position: '5:1',
           rule: 'test-rule-e',
         }],
@@ -255,10 +282,10 @@ describe('processResults', () => {
     expect(report).toStrictEqual({
       results: {
         'file.md': [{
-          ...commonResult,
+          ...commonFormattedResult,
           rule: 'MD001',
         }, {
-          ...commonResult,
+          ...commonFormattedResult,
           rule: 'MD002',
         }],
       },

--- a/src/linters/markdownlint/process-results.ts
+++ b/src/linters/markdownlint/process-results.ts
@@ -23,23 +23,28 @@ const processResults = (results: LintResults): LintReport => {
 
     reportResults[file] = []
 
-    // Aggregate counts
-    reportSummary.errorCount += errors.length
-
     // Process errors
     errors
       .sort((a, b) => a.lineNumber - b.lineNumber || (a.ruleNames.at(1) ?? a.ruleNames[0]).localeCompare(b.ruleNames.at(1) ?? b.ruleNames[0]))
-      .forEach(({ errorDetail, errorRange, fixInfo, lineNumber, ruleDescription, ruleNames }) => {
+      .forEach(({ errorDetail, errorRange, fixInfo, lineNumber, ruleDescription, ruleNames, severity }) => {
+        const isWarning = severity === 'warning'
+
         reportResults[file].push(formatResult({
           column: errorRange?.length ? errorRange[0] : undefined,
           line: lineNumber,
           message: errorDetail?.length ? `${ruleDescription}: ${errorDetail}` : ruleDescription,
           rule: ruleNames.at(1) ?? ruleNames[0],
-          severity: RuleSeverity.ERROR,
+          severity: isWarning ? RuleSeverity.WARNING : RuleSeverity.ERROR,
         }))
 
+        // Aggregate counts
+        reportSummary[isWarning ? 'warningCount' : 'errorCount'] += 1
         if (fixInfo) {
-          reportSummary.fixableErrorCount += 1
+          if (isWarning) {
+            reportSummary.fixableWarningCount += 1
+          } else {
+            reportSummary.fixableErrorCount += 1
+          }
         }
       })
   })

--- a/src/linters/stylelint/__tests__/lint-files.spec.ts
+++ b/src/linters/stylelint/__tests__/lint-files.spec.ts
@@ -147,12 +147,15 @@ describe('lintFiles', () => {
     })
   })
 
-  it('exits the process when `stylelint.lint` throws an error', async () => {
+  test.each([
+    ['loadConfig', mockLoadConfig],
+    ['lint', mockLint],
+  ])('exits the process when `%s` throws an error', async (_name, mock) => {
     expect.assertions(2)
 
     const error = new Error('Test error')
 
-    mockLint.mockRejectedValueOnce(error)
+    mock.mockRejectedValueOnce(error)
 
     try {
       await lintFiles(commonLintOptions)

--- a/src/linters/stylelint/__tests__/lint-files.spec.ts
+++ b/src/linters/stylelint/__tests__/lint-files.spec.ts
@@ -56,7 +56,7 @@ describe('lintFiles', () => {
 
     await lintFiles(commonLintOptions)
 
-    expect(mockLoadConfig).toHaveBeenCalledTimes(1)
+    expect(mockLoadConfig).toHaveBeenCalledOnceWith('index.css')
     expect(mockLint).toHaveBeenCalledOnceWith(commonStylelintOptions)
   })
 
@@ -69,7 +69,7 @@ describe('lintFiles', () => {
 
     await lintFiles(commonLintOptions)
 
-    expect(mockLoadConfig).toHaveBeenCalledTimes(1)
+    expect(mockLoadConfig).toHaveBeenCalledOnceWith('index.css')
     expect(mockLint).toHaveBeenCalledOnceWith({
       ...commonStylelintOptions,
       config,

--- a/src/linters/stylelint/__tests__/lint-files.spec.ts
+++ b/src/linters/stylelint/__tests__/lint-files.spec.ts
@@ -46,7 +46,6 @@ describe('lintFiles', () => {
   const stylelintLintMock = jest.mocked(stylelint.lint).mockImplementation(async () => ({
     cwd: '',
     errored: false,
-    output: '',
     report: '',
     reportedDisables: [],
     results: mockedLintResults,

--- a/src/linters/stylelint/__tests__/lint-files.spec.ts
+++ b/src/linters/stylelint/__tests__/lint-files.spec.ts
@@ -5,8 +5,11 @@ import stylelint from 'stylelint'
 import { colourLog } from '@Utils/colour-log'
 
 import { lintFiles } from '../lint-files'
+import { loadConfig } from '../load-config'
 
 import type { LintResult } from 'stylelint'
+
+jest.mock('../load-config')
 
 describe('lintFiles', () => {
 
@@ -20,7 +23,6 @@ describe('lintFiles', () => {
     allowEmptyInput: true,
     cache: false,
     cacheLocation: undefined,
-    config: expect.any(Object),
     files: ['index.css'],
     fix: false,
     quietDeprecationWarnings: true,
@@ -39,6 +41,7 @@ describe('lintFiles', () => {
     warnings: [],
   }]
 
+  const mockLoadConfig = jest.mocked(loadConfig).mockResolvedValue(undefined)
   const mockStylelint = jest.mocked(stylelint.lint).mockImplementation(async () => ({
     cwd: '',
     errored: false,
@@ -47,6 +50,31 @@ describe('lintFiles', () => {
     results: mockLintResults,
     ruleMetadata: {},
   }))
+
+  it('lints with no config when `loadConfig` returns undefined', async () => {
+    expect.assertions(2)
+
+    await lintFiles(commonLintOptions)
+
+    expect(mockLoadConfig).toHaveBeenCalledTimes(1)
+    expect(mockStylelint).toHaveBeenCalledOnceWith(commonStylelintOptions)
+  })
+
+  it('lints with config returned by `loadConfig`', async () => {
+    expect.assertions(2)
+
+    const config = { rules: { 'no-empty-source': true } }
+
+    mockLoadConfig.mockResolvedValueOnce(config)
+
+    await lintFiles(commonLintOptions)
+
+    expect(mockLoadConfig).toHaveBeenCalledTimes(1)
+    expect(mockStylelint).toHaveBeenCalledOnceWith({
+      ...commonStylelintOptions,
+      config,
+    })
+  })
 
   it('lints files with caching disabled when `cache` is false', async () => {
     expect.assertions(1)

--- a/src/linters/stylelint/__tests__/lint-files.spec.ts
+++ b/src/linters/stylelint/__tests__/lint-files.spec.ts
@@ -63,14 +63,14 @@ describe('lintFiles', () => {
   it('lints with the configFile returned by `resolveConfigFile`', async () => {
     expect.assertions(2)
 
-    mockResolveConfigFile.mockResolvedValueOnce('./lib/stylelint.config.js')
+    mockResolveConfigFile.mockResolvedValueOnce('./stylelint.config')
 
     await lintFiles(commonLintOptions)
 
     expect(mockResolveConfigFile).toHaveBeenCalledOnceWith('index.css')
     expect(mockLint).toHaveBeenCalledOnceWith({
       ...commonStylelintOptions,
-      configFile: './lib/stylelint.config.js',
+      configFile: './stylelint.config',
     })
   })
 

--- a/src/linters/stylelint/__tests__/lint-files.spec.ts
+++ b/src/linters/stylelint/__tests__/lint-files.spec.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import stylelint from 'stylelint'
+import { lint } from 'stylelint'
 
 import { colourLog } from '@Utils/colour-log'
 
@@ -41,8 +41,7 @@ describe('lintFiles', () => {
     warnings: [],
   }]
 
-  const mockLoadConfig = jest.mocked(loadConfig).mockResolvedValue(undefined)
-  const mockStylelint = jest.mocked(stylelint.lint).mockImplementation(async () => ({
+  const mockLint = jest.mocked(lint).mockImplementation(async () => ({
     cwd: '',
     errored: false,
     report: '',
@@ -50,6 +49,7 @@ describe('lintFiles', () => {
     results: mockLintResults,
     ruleMetadata: {},
   }))
+  const mockLoadConfig = jest.mocked(loadConfig).mockResolvedValue(undefined)
 
   it('lints with no config when `loadConfig` returns undefined', async () => {
     expect.assertions(2)
@@ -57,7 +57,7 @@ describe('lintFiles', () => {
     await lintFiles(commonLintOptions)
 
     expect(mockLoadConfig).toHaveBeenCalledTimes(1)
-    expect(mockStylelint).toHaveBeenCalledOnceWith(commonStylelintOptions)
+    expect(mockLint).toHaveBeenCalledOnceWith(commonStylelintOptions)
   })
 
   it('lints with config returned by `loadConfig`', async () => {
@@ -70,7 +70,7 @@ describe('lintFiles', () => {
     await lintFiles(commonLintOptions)
 
     expect(mockLoadConfig).toHaveBeenCalledTimes(1)
-    expect(mockStylelint).toHaveBeenCalledOnceWith({
+    expect(mockLint).toHaveBeenCalledOnceWith({
       ...commonStylelintOptions,
       config,
     })
@@ -84,7 +84,7 @@ describe('lintFiles', () => {
       cache: false,
     })
 
-    expect(mockStylelint).toHaveBeenCalledOnceWith(commonStylelintOptions)
+    expect(mockLint).toHaveBeenCalledOnceWith(commonStylelintOptions)
   })
 
   it('lints files with caching enabled when `cache` is true', async () => {
@@ -95,7 +95,7 @@ describe('lintFiles', () => {
       cache: true,
     })
 
-    expect(mockStylelint).toHaveBeenCalledOnceWith({
+    expect(mockLint).toHaveBeenCalledOnceWith({
       ...commonStylelintOptions,
       cache: true,
       cacheLocation: expect.stringContaining('.cache/lint/stylelint'),
@@ -110,7 +110,7 @@ describe('lintFiles', () => {
       fix: false
     })
 
-    expect(mockStylelint).toHaveBeenCalledOnceWith(commonStylelintOptions)
+    expect(mockLint).toHaveBeenCalledOnceWith(commonStylelintOptions)
   })
 
   it('lints files with fix enabled when `fix` is true', async () => {
@@ -121,7 +121,7 @@ describe('lintFiles', () => {
       fix: true
     })
 
-    expect(mockStylelint).toHaveBeenCalledOnceWith({
+    expect(mockLint).toHaveBeenCalledOnceWith({
       ...commonStylelintOptions,
       fix: true,
     })
@@ -132,7 +132,7 @@ describe('lintFiles', () => {
 
     const result = await lintFiles(commonLintOptions)
 
-    expect(mockStylelint).toHaveBeenCalledOnceWith(commonStylelintOptions)
+    expect(mockLint).toHaveBeenCalledOnceWith(commonStylelintOptions)
     expect(result).toStrictEqual({
       results: {},
       summary: {
@@ -152,7 +152,7 @@ describe('lintFiles', () => {
 
     const error = new Error('Test error')
 
-    mockStylelint.mockRejectedValueOnce(error)
+    mockLint.mockRejectedValueOnce(error)
 
     try {
       await lintFiles(commonLintOptions)

--- a/src/linters/stylelint/__tests__/lint-files.spec.ts
+++ b/src/linters/stylelint/__tests__/lint-files.spec.ts
@@ -8,10 +8,6 @@ import { lintFiles } from '../lint-files'
 
 import type { LintResult } from 'stylelint'
 
-jest.mock('stylelint', () => ({
-  lint: jest.fn(),
-}))
-
 describe('lintFiles', () => {
 
   const commonLintOptions = {
@@ -52,7 +48,7 @@ describe('lintFiles', () => {
     ruleMetadata: {},
   }))
 
-  it('lints files with cacheing disabled when `cache` is false', async () => {
+  it('lints files with caching disabled when `cache` is false', async () => {
     expect.assertions(1)
 
     await lintFiles({
@@ -63,7 +59,7 @@ describe('lintFiles', () => {
     expect(stylelintLintMock).toHaveBeenCalledOnceWith(commonStylelintOptions)
   })
 
-  it('lints files with cacheing enabled when `cache` is true', async () => {
+  it('lints files with caching enabled when `cache` is true', async () => {
     expect.assertions(1)
 
     await lintFiles({

--- a/src/linters/stylelint/__tests__/lint-files.spec.ts
+++ b/src/linters/stylelint/__tests__/lint-files.spec.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { lint } from 'stylelint'
+import stylelint from 'stylelint'
 
 import { colourLog } from '@Utils/colour-log'
 
@@ -41,7 +41,7 @@ describe('lintFiles', () => {
     warnings: [],
   }]
 
-  const mockLint = jest.mocked(lint).mockImplementation(async () => ({
+  const mockLint = jest.mocked(stylelint.lint).mockImplementation(async () => ({
     cwd: '',
     errored: false,
     report: '',

--- a/src/linters/stylelint/__tests__/lint-files.spec.ts
+++ b/src/linters/stylelint/__tests__/lint-files.spec.ts
@@ -5,11 +5,11 @@ import stylelint from 'stylelint'
 import { colourLog } from '@Utils/colour-log'
 
 import { lintFiles } from '../lint-files'
-import { loadConfig } from '../load-config'
+import { resolveConfigFile } from '../resolve-config'
 
 import type { LintResult } from 'stylelint'
 
-jest.mock('../load-config')
+jest.mock('../resolve-config')
 
 describe('lintFiles', () => {
 
@@ -49,30 +49,28 @@ describe('lintFiles', () => {
     results: mockLintResults,
     ruleMetadata: {},
   }))
-  const mockLoadConfig = jest.mocked(loadConfig).mockResolvedValue(undefined)
+  const mockResolveConfigFile = jest.mocked(resolveConfigFile).mockResolvedValue(undefined)
 
-  it('lints with no config when `loadConfig` returns undefined', async () => {
+  it('lints with no configFile when `resolveConfigFile` returns undefined', async () => {
     expect.assertions(2)
 
     await lintFiles(commonLintOptions)
 
-    expect(mockLoadConfig).toHaveBeenCalledOnceWith('index.css')
+    expect(mockResolveConfigFile).toHaveBeenCalledOnceWith('index.css')
     expect(mockLint).toHaveBeenCalledOnceWith(commonStylelintOptions)
   })
 
-  it('lints with config returned by `loadConfig`', async () => {
+  it('lints with the configFile returned by `resolveConfigFile`', async () => {
     expect.assertions(2)
 
-    const config = { rules: { 'no-empty-source': true } }
-
-    mockLoadConfig.mockResolvedValueOnce(config)
+    mockResolveConfigFile.mockResolvedValueOnce('./lib/stylelint.config.js')
 
     await lintFiles(commonLintOptions)
 
-    expect(mockLoadConfig).toHaveBeenCalledOnceWith('index.css')
+    expect(mockResolveConfigFile).toHaveBeenCalledOnceWith('index.css')
     expect(mockLint).toHaveBeenCalledOnceWith({
       ...commonStylelintOptions,
-      config,
+      configFile: './lib/stylelint.config.js',
     })
   })
 
@@ -148,7 +146,7 @@ describe('lintFiles', () => {
   })
 
   test.each([
-    ['loadConfig', mockLoadConfig],
+    ['resolveConfigFile', mockResolveConfigFile],
     ['lint', mockLint],
   ])('exits the process when `%s` throws an error', async (_name, mock) => {
     expect.assertions(2)

--- a/src/linters/stylelint/__tests__/lint-files.spec.ts
+++ b/src/linters/stylelint/__tests__/lint-files.spec.ts
@@ -12,7 +12,7 @@ describe('lintFiles', () => {
 
   const commonLintOptions = {
     cache: false,
-    files: ['index.scss'],
+    files: ['index.css'],
     fix: false,
   }
 
@@ -21,7 +21,7 @@ describe('lintFiles', () => {
     cache: false,
     cacheLocation: undefined,
     config: expect.any(Object),
-    files: ['index.scss'],
+    files: ['index.css'],
     fix: false,
     quietDeprecationWarnings: true,
     reportDescriptionlessDisables: true,
@@ -29,22 +29,22 @@ describe('lintFiles', () => {
     reportNeedlessDisables: true,
   }
 
-  const mockedLintResults: Array<LintResult> = [{
+  const mockLintResults: Array<LintResult> = [{
     deprecations: [],
     errored: false,
     ignored: false,
     invalidOptionWarnings: [],
     parseErrors: [],
-    source: path.join(process.cwd(), 'index.scss'),
+    source: path.join(process.cwd(), 'index.css'),
     warnings: [],
   }]
 
-  const stylelintLintMock = jest.mocked(stylelint.lint).mockImplementation(async () => ({
+  const mockStylelint = jest.mocked(stylelint.lint).mockImplementation(async () => ({
     cwd: '',
     errored: false,
     report: '',
     reportedDisables: [],
-    results: mockedLintResults,
+    results: mockLintResults,
     ruleMetadata: {},
   }))
 
@@ -56,7 +56,7 @@ describe('lintFiles', () => {
       cache: false,
     })
 
-    expect(stylelintLintMock).toHaveBeenCalledOnceWith(commonStylelintOptions)
+    expect(mockStylelint).toHaveBeenCalledOnceWith(commonStylelintOptions)
   })
 
   it('lints files with caching enabled when `cache` is true', async () => {
@@ -67,7 +67,7 @@ describe('lintFiles', () => {
       cache: true,
     })
 
-    expect(stylelintLintMock).toHaveBeenCalledOnceWith({
+    expect(mockStylelint).toHaveBeenCalledOnceWith({
       ...commonStylelintOptions,
       cache: true,
       cacheLocation: expect.stringContaining('.cache/lint/stylelint'),
@@ -82,7 +82,7 @@ describe('lintFiles', () => {
       fix: false
     })
 
-    expect(stylelintLintMock).toHaveBeenCalledOnceWith(commonStylelintOptions)
+    expect(mockStylelint).toHaveBeenCalledOnceWith(commonStylelintOptions)
   })
 
   it('lints files with fix enabled when `fix` is true', async () => {
@@ -93,7 +93,7 @@ describe('lintFiles', () => {
       fix: true
     })
 
-    expect(stylelintLintMock).toHaveBeenCalledOnceWith({
+    expect(mockStylelint).toHaveBeenCalledOnceWith({
       ...commonStylelintOptions,
       fix: true,
     })
@@ -104,7 +104,7 @@ describe('lintFiles', () => {
 
     const result = await lintFiles(commonLintOptions)
 
-    expect(stylelintLintMock).toHaveBeenCalledOnceWith(commonStylelintOptions)
+    expect(mockStylelint).toHaveBeenCalledOnceWith(commonStylelintOptions)
     expect(result).toStrictEqual({
       results: {},
       summary: {
@@ -124,7 +124,7 @@ describe('lintFiles', () => {
 
     const error = new Error('Test error')
 
-    stylelintLintMock.mockRejectedValueOnce(error)
+    mockStylelint.mockRejectedValueOnce(error)
 
     try {
       await lintFiles(commonLintOptions)

--- a/src/linters/stylelint/__tests__/load-config.spec.ts
+++ b/src/linters/stylelint/__tests__/load-config.spec.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { resolveConfig } from 'stylelint'
+import stylelint from 'stylelint'
 
 import { colourLog } from '@Utils/colour-log'
 
@@ -12,12 +12,12 @@ describe('loadConfig', () => {
   test.each([
     ['a file is provided', 'index.css', path.join(process.cwd(), 'index.css')],
     ['no file is provided', undefined, path.join(process.cwd(), 'style.css')],
-  ])('calls `resolveConfig` with the correct search path when %s', async (_title, filePath, expectedPath) => {
+  ])('calls `stylelint.resolveConfig` with the correct search path when %s', async (_title, filePath, expectedPath) => {
     expect.assertions(1)
 
     await loadConfig(filePath)
 
-    expect(resolveConfig).toHaveBeenCalledOnceWith(expectedPath)
+    expect(stylelint.resolveConfig).toHaveBeenCalledOnceWith(expectedPath)
   })
 
   it('returns undefined if custom config exists', async () => {
@@ -25,7 +25,7 @@ describe('loadConfig', () => {
 
     const customConfig = { rules: { 'no-empty-source': true } }
 
-    jest.mocked(resolveConfig).mockResolvedValueOnce(customConfig)
+    jest.mocked(stylelint.resolveConfig).mockResolvedValueOnce(customConfig)
 
     const config = await loadConfig('index.css')
 
@@ -36,7 +36,7 @@ describe('loadConfig', () => {
   it('returns the default config if no custom config exists', async () => {
     expect.assertions(2)
 
-    jest.mocked(resolveConfig).mockResolvedValueOnce(undefined)
+    jest.mocked(stylelint.resolveConfig).mockResolvedValueOnce(undefined)
 
     const config = await loadConfig()
 
@@ -44,12 +44,12 @@ describe('loadConfig', () => {
     expect(config).toStrictEqual(expect.objectContaining(defaultConfig))
   })
 
-  it('exits the process when `resolveConfig` throws an error', async () => {
+  it('exits the process when `stylelint.resolveConfig` throws an error', async () => {
     expect.assertions(2)
 
     const error = new Error('Test error')
 
-    jest.mocked(resolveConfig).mockImplementation(() => {
+    jest.mocked(stylelint.resolveConfig).mockImplementation(() => {
       throw error
     })
 

--- a/src/linters/stylelint/__tests__/load-config.spec.ts
+++ b/src/linters/stylelint/__tests__/load-config.spec.ts
@@ -1,0 +1,51 @@
+import stylelint from 'stylelint'
+
+import { colourLog } from '@Utils/colour-log'
+
+import defaultConfig from '../../../../config/stylelint.config'
+import { loadConfig } from '../load-config'
+
+describe('loadConfig', () => {
+
+  it('returns undefined if custom config exists', async () => {
+    expect.assertions(2)
+
+    const customConfig = { rules: { 'no-empty-source': true } }
+
+    jest.mocked(stylelint.resolveConfig).mockResolvedValueOnce(customConfig)
+
+    const config = await loadConfig()
+
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using custom Stylelint config:', customConfig)
+    expect(config).toStrictEqual(undefined)
+  })
+
+  it('returns the default config if no custom config exists', async () => {
+    expect.assertions(2)
+
+    jest.mocked(stylelint.resolveConfig).mockResolvedValueOnce(undefined)
+
+    const config = await loadConfig()
+
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using default Stylelint config:', expect.objectContaining(defaultConfig))
+    expect(config).toStrictEqual(expect.objectContaining(defaultConfig))
+  })
+
+  it('exits the process when `stylelint.resolveConfig` throws an error', async () => {
+    expect.assertions(2)
+
+    const error = new Error('Test error')
+
+    jest.mocked(stylelint.resolveConfig).mockImplementation(() => {
+      throw error
+    })
+
+    try {
+      await loadConfig()
+    } catch {
+      expect(colourLog.error).toHaveBeenCalledWith('An error occurred while loading the Stylelint config', error)
+      expect(process.exit).toHaveBeenCalledWith(1)
+    }
+  })
+
+})

--- a/src/linters/stylelint/__tests__/load-config.spec.ts
+++ b/src/linters/stylelint/__tests__/load-config.spec.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { resolveConfig } from 'stylelint'
 
 import { colourLog } from '@Utils/colour-log'
@@ -7,8 +9,22 @@ import { loadConfig } from '../load-config'
 
 describe('loadConfig', () => {
 
-  it('returns undefined if custom config exists', async () => {
-    expect.assertions(2)
+  it('returns undefined if custom config exists for a given file', async () => {
+    expect.assertions(3)
+
+    const customConfig = { rules: { 'no-empty-source': true } }
+
+    jest.mocked(resolveConfig).mockResolvedValueOnce(customConfig)
+
+    const config = await loadConfig('index.css')
+
+    expect(resolveConfig).toHaveBeenCalledOnceWith(path.join(process.cwd(), 'index.css'))
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using custom Stylelint config:', customConfig)
+    expect(config).toStrictEqual(undefined)
+  })
+
+  it('returns undefined if custom config exists when no file is provided', async () => {
+    expect.assertions(3)
 
     const customConfig = { rules: { 'no-empty-source': true } }
 
@@ -16,6 +32,7 @@ describe('loadConfig', () => {
 
     const config = await loadConfig()
 
+    expect(resolveConfig).toHaveBeenCalledOnceWith(path.join(process.cwd(), 'style.css'))
     expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using custom Stylelint config:', customConfig)
     expect(config).toStrictEqual(undefined)
   })

--- a/src/linters/stylelint/__tests__/load-config.spec.ts
+++ b/src/linters/stylelint/__tests__/load-config.spec.ts
@@ -9,8 +9,19 @@ import { loadConfig } from '../load-config'
 
 describe('loadConfig', () => {
 
-  it('returns undefined if custom config exists for a given file', async () => {
-    expect.assertions(3)
+  test.each([
+    ['a file is provided', 'index.css', path.join(process.cwd(), 'index.css')],
+    ['no file is provided', undefined, path.join(process.cwd(), 'style.css')],
+  ])('calls `resolveConfig` with the correct search path when %s', async (_title, filePath, expectedPath) => {
+    expect.assertions(1)
+
+    await loadConfig(filePath)
+
+    expect(resolveConfig).toHaveBeenCalledOnceWith(expectedPath)
+  })
+
+  it('returns undefined if custom config exists', async () => {
+    expect.assertions(2)
 
     const customConfig = { rules: { 'no-empty-source': true } }
 
@@ -18,21 +29,6 @@ describe('loadConfig', () => {
 
     const config = await loadConfig('index.css')
 
-    expect(resolveConfig).toHaveBeenCalledOnceWith(path.join(process.cwd(), 'index.css'))
-    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using custom Stylelint config:', customConfig)
-    expect(config).toStrictEqual(undefined)
-  })
-
-  it('returns undefined if custom config exists when no file is provided', async () => {
-    expect.assertions(3)
-
-    const customConfig = { rules: { 'no-empty-source': true } }
-
-    jest.mocked(resolveConfig).mockResolvedValueOnce(customConfig)
-
-    const config = await loadConfig()
-
-    expect(resolveConfig).toHaveBeenCalledOnceWith(path.join(process.cwd(), 'style.css'))
     expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using custom Stylelint config:', customConfig)
     expect(config).toStrictEqual(undefined)
   })

--- a/src/linters/stylelint/__tests__/load-config.spec.ts
+++ b/src/linters/stylelint/__tests__/load-config.spec.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 import stylelint from 'stylelint'
 
 import { colourLog } from '@Utils/colour-log'
@@ -9,42 +7,57 @@ import { loadConfig } from '../load-config'
 
 describe('loadConfig', () => {
 
-  test.each([
-    ['a file is provided', 'index.css', path.join(process.cwd(), 'index.css')],
-    ['no file is provided', undefined, path.join(process.cwd(), 'style.css')],
-  ])('calls `stylelint.resolveConfig` with the correct search path when %s', async (_title, filePath, expectedPath) => {
-    expect.assertions(1)
-
-    await loadConfig(filePath)
-
-    expect(stylelint.resolveConfig).toHaveBeenCalledOnceWith(expectedPath)
-  })
-
-  it('returns undefined if custom config exists', async () => {
-    expect.assertions(2)
+  it('returns `undefined` if custom config exists', async () => {
+    expect.assertions(3)
 
     const customConfig = { rules: { 'no-empty-source': true } }
 
     jest.mocked(stylelint.resolveConfig).mockResolvedValueOnce(customConfig)
 
-    const config = await loadConfig('index.css')
+    const config = await loadConfig('style.css')
 
+    expect(stylelint.resolveConfig).toHaveBeenCalledOnceWith('style.css')
     expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using custom Stylelint config:', customConfig)
     expect(config).toStrictEqual(undefined)
   })
 
-  it('returns the default config if no custom config exists', async () => {
-    expect.assertions(2)
-
-    jest.mocked(stylelint.resolveConfig).mockResolvedValueOnce(undefined)
+  it('returns the default config when no file is provided', async () => {
+    expect.assertions(3)
 
     const config = await loadConfig()
 
+    expect(stylelint.resolveConfig).not.toHaveBeenCalled()
     expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using default Stylelint config:', expect.objectContaining(defaultConfig))
     expect(config).toStrictEqual(expect.objectContaining(defaultConfig))
   })
 
-  it('exits the process when `stylelint.resolveConfig` throws an error', async () => {
+  it('returns the default config when `stylelint.resolveConfig` returns `undefined`', async () => {
+    expect.assertions(3)
+
+    jest.mocked(stylelint.resolveConfig).mockResolvedValueOnce(undefined)
+
+    const config = await loadConfig('style.css')
+
+    expect(stylelint.resolveConfig).toHaveBeenCalledOnceWith('style.css')
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using default Stylelint config:', expect.objectContaining(defaultConfig))
+    expect(config).toStrictEqual(expect.objectContaining(defaultConfig))
+  })
+
+  it('returns the default config when `stylelint.resolveConfig` throws with a `ConfigurationError`', async () => {
+    expect.assertions(3)
+
+    const configError = Object.assign(new Error('No configuration provided'), { name: 'ConfigurationError' })
+
+    jest.mocked(stylelint.resolveConfig).mockRejectedValueOnce(configError)
+
+    const config = await loadConfig('style.css')
+
+    expect(stylelint.resolveConfig).toHaveBeenCalledOnceWith('style.css')
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using default Stylelint config:', expect.objectContaining(defaultConfig))
+    expect(config).toStrictEqual(expect.objectContaining(defaultConfig))
+  })
+
+  it('exits the process when `stylelint.resolveConfig` throws an unexpected error', async () => {
     expect.assertions(2)
 
     const error = new Error('Test error')
@@ -54,7 +67,7 @@ describe('loadConfig', () => {
     })
 
     try {
-      await loadConfig()
+      await loadConfig('style.css')
     } catch {
       expect(colourLog.error).toHaveBeenCalledWith('An error occurred while loading the Stylelint config', error)
       expect(process.exit).toHaveBeenCalledWith(1)

--- a/src/linters/stylelint/__tests__/load-config.spec.ts
+++ b/src/linters/stylelint/__tests__/load-config.spec.ts
@@ -1,4 +1,4 @@
-import stylelint from 'stylelint'
+import { resolveConfig } from 'stylelint'
 
 import { colourLog } from '@Utils/colour-log'
 
@@ -12,7 +12,7 @@ describe('loadConfig', () => {
 
     const customConfig = { rules: { 'no-empty-source': true } }
 
-    jest.mocked(stylelint.resolveConfig).mockResolvedValueOnce(customConfig)
+    jest.mocked(resolveConfig).mockResolvedValueOnce(customConfig)
 
     const config = await loadConfig()
 
@@ -23,7 +23,7 @@ describe('loadConfig', () => {
   it('returns the default config if no custom config exists', async () => {
     expect.assertions(2)
 
-    jest.mocked(stylelint.resolveConfig).mockResolvedValueOnce(undefined)
+    jest.mocked(resolveConfig).mockResolvedValueOnce(undefined)
 
     const config = await loadConfig()
 
@@ -31,12 +31,12 @@ describe('loadConfig', () => {
     expect(config).toStrictEqual(expect.objectContaining(defaultConfig))
   })
 
-  it('exits the process when `stylelint.resolveConfig` throws an error', async () => {
+  it('exits the process when `resolveConfig` throws an error', async () => {
     expect.assertions(2)
 
     const error = new Error('Test error')
 
-    jest.mocked(stylelint.resolveConfig).mockImplementation(() => {
+    jest.mocked(resolveConfig).mockImplementation(() => {
       throw error
     })
 

--- a/src/linters/stylelint/__tests__/process-results.spec.ts
+++ b/src/linters/stylelint/__tests__/process-results.spec.ts
@@ -8,13 +8,13 @@ import type { LintResult, Warning } from 'stylelint'
 
 describe('processResults', () => {
 
-  const commonResult: LintResult = {
+  const commonLintResult: LintResult = {
     deprecations: [],
     errored: false,
     ignored: false,
     invalidOptionWarnings: [],
     parseErrors: [],
-    source: path.join(process.cwd(), 'file.scss'),
+    source: path.join(process.cwd(), 'file.css'),
     warnings: [],
   }
 
@@ -45,14 +45,14 @@ describe('processResults', () => {
 
   it('normalises file paths relative to the cwd', () => {
     const report = processResults([{
-      ...commonResult,
-      source: path.join(process.cwd(), 'file.scss'),
+      ...commonLintResult,
+      source: path.join(process.cwd(), 'file.css'),
       warnings: [commonWarning],
     }], {})
 
     expect(report).toStrictEqual({
       results: {
-        'file.scss': expect.any(Array),
+        'file.css': expect.any(Array),
       },
       summary: expect.objectContaining({
         fileCount: 1,
@@ -62,7 +62,7 @@ describe('processResults', () => {
 
   it('returns "unknown-source" for results without a source', () => {
     const report = processResults([{
-      ...commonResult,
+      ...commonLintResult,
       source: '',
       warnings: [commonWarning],
     }], {})
@@ -79,18 +79,18 @@ describe('processResults', () => {
 
   it('does not report results for files which have no warnings', () => {
     const report = processResults([{
-      ...commonResult,
-      source: path.join(process.cwd(), 'file.scss'),
+      ...commonLintResult,
+      source: path.join(process.cwd(), 'file.css'),
       warnings: [commonWarning],
     }, {
-      ...commonResult,
-      source: path.join(process.cwd(), 'file-2.scss'),
+      ...commonLintResult,
+      source: path.join(process.cwd(), 'file-2.css'),
       warnings: [],
     }], {})
 
     expect(report).toStrictEqual({
       results: {
-        'file.scss': expect.any(Array),
+        'file.css': expect.any(Array),
       },
       summary: expect.objectContaining({
         fileCount: 2,
@@ -100,22 +100,22 @@ describe('processResults', () => {
 
   it('aggregates error and warning counts', () => {
     const report = processResults([{
-      ...commonResult,
-      source: path.join(process.cwd(), 'file.scss'),
+      ...commonLintResult,
+      source: path.join(process.cwd(), 'file.css'),
       warnings: [
         { ...commonWarning, severity: 'error' },
         { ...commonWarning, severity: 'warning' }
       ],
     }, {
-      ...commonResult,
-      source: path.join(process.cwd(), 'file-2.scss'),
+      ...commonLintResult,
+      source: path.join(process.cwd(), 'file-2.css'),
       warnings: [
         { ...commonWarning, severity: 'error', rule: 'fixable-rule' },
         { ...commonWarning, severity: 'error' },
       ],
     }, {
-      ...commonResult,
-      source: path.join(process.cwd(), 'file-3.scss'),
+      ...commonLintResult,
+      source: path.join(process.cwd(), 'file-3.css'),
       warnings: [
         { ...commonWarning, severity: 'error', rule: 'fixable-rule' },
         { ...commonWarning, severity: 'warning', rule: 'fixable-rule' },
@@ -126,9 +126,9 @@ describe('processResults', () => {
 
     expect(report).toStrictEqual({
       results: {
-        'file.scss': expect.any(Array),
-        'file-2.scss': expect.any(Array),
-        'file-3.scss': expect.any(Array),
+        'file.css': expect.any(Array),
+        'file-2.css': expect.any(Array),
+        'file-3.css': expect.any(Array),
       },
       summary: {
         deprecatedRules: [],
@@ -144,8 +144,8 @@ describe('processResults', () => {
 
   it('formats warning messages', () => {
     const report = processResults([{
-      ...commonResult,
-      source: path.join(process.cwd(), 'file.scss'),
+      ...commonLintResult,
+      source: path.join(process.cwd(), 'file.css'),
       warnings: [{
         column: 2,
         line: 3,
@@ -157,7 +157,7 @@ describe('processResults', () => {
 
     expect(report).toStrictEqual({
       results: {
-        'file.scss': [{
+        'file.css': [{
           ...expectedResultThemes,
           position: '3:2',
           message: 'Test warning',
@@ -179,8 +179,8 @@ describe('processResults', () => {
 
   it('formats error messages', () => {
     const report = processResults([{
-      ...commonResult,
-      source: path.join(process.cwd(), 'file.scss'),
+      ...commonLintResult,
+      source: path.join(process.cwd(), 'file.css'),
       warnings: [{
         column: 10,
         line: 8,
@@ -192,7 +192,7 @@ describe('processResults', () => {
 
     expect(report).toStrictEqual({
       results: {
-        'file.scss': [{
+        'file.css': [{
           ...expectedResultThemes,
           position: '8:10',
           message: 'Test error',
@@ -214,8 +214,8 @@ describe('processResults', () => {
 
   it('formats multiple messages for a single file', () => {
     const report = processResults([{
-      ...commonResult,
-      source: path.join(process.cwd(), 'file.scss'),
+      ...commonLintResult,
+      source: path.join(process.cwd(), 'file.css'),
       warnings: [{
         column: 1,
         line: 10,
@@ -245,7 +245,7 @@ describe('processResults', () => {
 
     expect(report).toStrictEqual({
       results: {
-        'file.scss': [{
+        'file.css': [{
           ...expectedResultThemes,
           position: '10:1',
           message: 'First warning',
@@ -285,27 +285,27 @@ describe('processResults', () => {
 
   it('accumulates deprecated rules without duplicates', () => {
     const report = processResults([{
-      ...commonResult,
+      ...commonLintResult,
       deprecations: [{
         text: 'deprecated-rule-1',
       }, {
         text: 'deprecated-rule-2',
       }],
-      source: path.join(process.cwd(), 'file.scss'),
+      source: path.join(process.cwd(), 'file.css'),
       warnings: [commonWarning],
     }, {
-      ...commonResult,
+      ...commonLintResult,
       deprecations: [{
         text: 'deprecated-rule-1',
       }],
-      source: path.join(process.cwd(), 'file-2.scss'),
+      source: path.join(process.cwd(), 'file-2.css'),
       warnings: [commonWarning],
     }], {})
 
     expect(report).toStrictEqual({
       results: {
-        'file.scss': expect.any(Array),
-        'file-2.scss': expect.any(Array),
+        'file.css': expect.any(Array),
+        'file-2.css': expect.any(Array),
       },
       summary: {
         deprecatedRules: ['deprecated-rule-1', 'deprecated-rule-2'],

--- a/src/linters/stylelint/__tests__/resolve-config.spec.ts
+++ b/src/linters/stylelint/__tests__/resolve-config.spec.ts
@@ -2,10 +2,11 @@ import stylelint from 'stylelint'
 
 import { colourLog } from '@Utils/colour-log'
 
-import defaultConfig from '../../../../config/stylelint.config'
-import { loadConfig } from '../load-config'
+import { resolveConfigFile } from '../resolve-config'
 
-describe('loadConfig', () => {
+describe('resolveConfigFile', () => {
+
+  const expectedDefaultConfigPath = expect.stringContaining('stylelint.config')
 
   it('returns `undefined` if custom config exists', async () => {
     expect.assertions(3)
@@ -14,47 +15,47 @@ describe('loadConfig', () => {
 
     jest.mocked(stylelint.resolveConfig).mockResolvedValueOnce(customConfig)
 
-    const config = await loadConfig('style.css')
+    const config = await resolveConfigFile('style.css')
 
     expect(stylelint.resolveConfig).toHaveBeenCalledOnceWith('style.css')
     expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using custom Stylelint config:', customConfig)
     expect(config).toStrictEqual(undefined)
   })
 
-  it('returns the default config when no file is provided', async () => {
+  it('returns the path to the default config when no file is provided', async () => {
     expect.assertions(3)
 
-    const config = await loadConfig()
+    const config = await resolveConfigFile()
 
     expect(stylelint.resolveConfig).not.toHaveBeenCalled()
-    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using default Stylelint config:', expect.objectContaining(defaultConfig))
-    expect(config).toStrictEqual(expect.objectContaining(defaultConfig))
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using default Stylelint config:', expectedDefaultConfigPath)
+    expect(config).toStrictEqual(expectedDefaultConfigPath)
   })
 
-  it('returns the default config when `stylelint.resolveConfig` returns `undefined`', async () => {
+  it('returns the path to the default config when `stylelint.resolveConfig` returns `undefined`', async () => {
     expect.assertions(3)
 
     jest.mocked(stylelint.resolveConfig).mockResolvedValueOnce(undefined)
 
-    const config = await loadConfig('style.css')
+    const config = await resolveConfigFile('style.css')
 
     expect(stylelint.resolveConfig).toHaveBeenCalledOnceWith('style.css')
-    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using default Stylelint config:', expect.objectContaining(defaultConfig))
-    expect(config).toStrictEqual(expect.objectContaining(defaultConfig))
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using default Stylelint config:', expectedDefaultConfigPath)
+    expect(config).toStrictEqual(expectedDefaultConfigPath)
   })
 
-  it('returns the default config when `stylelint.resolveConfig` throws with a `ConfigurationError`', async () => {
+  it('returns the path to the default config when `stylelint.resolveConfig` throws with a `ConfigurationError`', async () => {
     expect.assertions(3)
 
     const configError = Object.assign(new Error('No configuration provided'), { name: 'ConfigurationError' })
 
     jest.mocked(stylelint.resolveConfig).mockRejectedValueOnce(configError)
 
-    const config = await loadConfig('style.css')
+    const config = await resolveConfigFile('style.css')
 
     expect(stylelint.resolveConfig).toHaveBeenCalledOnceWith('style.css')
-    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using default Stylelint config:', expect.objectContaining(defaultConfig))
-    expect(config).toStrictEqual(expect.objectContaining(defaultConfig))
+    expect(colourLog.configDebug).toHaveBeenCalledOnceWith('Using default Stylelint config:', expectedDefaultConfigPath)
+    expect(config).toStrictEqual(expectedDefaultConfigPath)
   })
 
   it('exits the process when `stylelint.resolveConfig` throws an unexpected error', async () => {
@@ -67,7 +68,7 @@ describe('loadConfig', () => {
     })
 
     try {
-      await loadConfig('style.css')
+      await resolveConfigFile('style.css')
     } catch {
       expect(colourLog.error).toHaveBeenCalledWith('An error occurred while loading the Stylelint config', error)
       expect(process.exit).toHaveBeenCalledWith(1)

--- a/src/linters/stylelint/lint-files.ts
+++ b/src/linters/stylelint/lint-files.ts
@@ -1,4 +1,4 @@
-import { lint } from 'stylelint'
+import stylelint from 'stylelint'
 
 import { Linter } from '@Types/lint'
 import { colourLog } from '@Utils/colour-log'
@@ -14,7 +14,7 @@ const lintFiles = async ({ cache, files, fix }: LintFilesOptions): Promise<LintR
     const config = await loadConfig(files[0])
 
     // Run Stylelint
-    const { results, ruleMetadata } = await lint({
+    const { results, ruleMetadata } = await stylelint.lint({
       ...(config && { config }),
       allowEmptyInput: true,
       cache,

--- a/src/linters/stylelint/lint-files.ts
+++ b/src/linters/stylelint/lint-files.ts
@@ -1,25 +1,24 @@
-import stylelint from 'stylelint'
+import { lint } from 'stylelint'
 
 import { Linter } from '@Types/lint'
 import { colourLog } from '@Utils/colour-log'
 import { getCacheDirectory } from '@Utils/cache'
 
+import { loadConfig } from './load-config'
 import { processResults } from './process-results'
 
 import type { LintFilesOptions, LintReport } from '@Types/lint'
 
 const lintFiles = async ({ cache, files, fix }: LintFilesOptions): Promise<LintReport> => {
   try {
+    const config = await loadConfig()
+
     // Run Stylelint
-    const { results, ruleMetadata } = await stylelint.lint({
+    const { results, ruleMetadata } = await lint({
+      ...(config && { config }),
       allowEmptyInput: true,
       cache,
       cacheLocation: cache ? getCacheDirectory(Linter.Stylelint) : undefined,
-      config: { // TODO: Replace with externally loaded or user-provided Stylelint config
-        rules: {
-          'declaration-block-no-duplicate-properties': true,
-        },
-      },
       files,
       fix,
       quietDeprecationWarnings: true,

--- a/src/linters/stylelint/lint-files.ts
+++ b/src/linters/stylelint/lint-files.ts
@@ -11,7 +11,7 @@ import type { LintFilesOptions, LintReport } from '@Types/lint'
 
 const lintFiles = async ({ cache, files, fix }: LintFilesOptions): Promise<LintReport> => {
   try {
-    const config = await loadConfig()
+    const config = await loadConfig(files[0])
 
     // Run Stylelint
     const { results, ruleMetadata } = await lint({

--- a/src/linters/stylelint/lint-files.ts
+++ b/src/linters/stylelint/lint-files.ts
@@ -4,18 +4,18 @@ import { Linter } from '@Types/lint'
 import { colourLog } from '@Utils/colour-log'
 import { getCacheDirectory } from '@Utils/cache'
 
-import { loadConfig } from './load-config'
 import { processResults } from './process-results'
+import { resolveConfigFile } from './resolve-config'
 
 import type { LintFilesOptions, LintReport } from '@Types/lint'
 
 const lintFiles = async ({ cache, files, fix }: LintFilesOptions): Promise<LintReport> => {
   try {
-    const config = await loadConfig(files[0])
+    const configFile = await resolveConfigFile(files[0])
 
     // Run Stylelint
     const { results, ruleMetadata } = await stylelint.lint({
-      ...(config && { config }),
+      ...(configFile && { configFile }),
       allowEmptyInput: true,
       cache,
       cacheLocation: cache ? getCacheDirectory(Linter.Stylelint) : undefined,

--- a/src/linters/stylelint/load-config.ts
+++ b/src/linters/stylelint/load-config.ts
@@ -1,0 +1,32 @@
+import path from 'node:path'
+
+import { resolveConfig } from 'stylelint'
+
+import { Linter } from '@Types/lint'
+import { colourLog } from '@Utils/colour-log'
+
+import defaultConfig from '../../../config/stylelint.config'
+
+import type { Config } from 'stylelint'
+
+const loadConfig = async (): Promise<Config | undefined> => {
+  try {
+    // Custom config
+    const customConfig = await resolveConfig(path.join(process.cwd(), 'index.css'))
+    if (customConfig) {
+      colourLog.configDebug(`Using custom ${Linter.Stylelint} config:`, customConfig)
+      return undefined // Stylelint will auto-discover it
+    }
+
+    // Default config
+    colourLog.configDebug(`Using default ${Linter.Stylelint} config:`, defaultConfig)
+    return defaultConfig
+  } catch (error) {
+    colourLog.error(`An error occurred while loading the ${Linter.Stylelint} config`, error)
+    process.exit(1)
+  }
+}
+
+export {
+  loadConfig,
+}

--- a/src/linters/stylelint/load-config.ts
+++ b/src/linters/stylelint/load-config.ts
@@ -9,10 +9,13 @@ import defaultConfig from '../../../config/stylelint.config'
 
 import type { Config } from 'stylelint'
 
-const loadConfig = async (): Promise<Config | undefined> => {
+const loadConfig = async (filePath?: string): Promise<Config | undefined> => {
   try {
     // Custom config
-    const customConfig = await resolveConfig(path.join(process.cwd(), 'index.css'))
+    const searchPath = filePath
+      ? path.resolve(filePath)
+      : path.join(process.cwd(), 'style.css')
+    const customConfig = await resolveConfig(searchPath)
     if (customConfig) {
       colourLog.configDebug(`Using custom ${Linter.Stylelint} config:`, customConfig)
       return undefined // Stylelint will auto-discover it

--- a/src/linters/stylelint/load-config.ts
+++ b/src/linters/stylelint/load-config.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { resolveConfig } from 'stylelint'
+import stylelint from 'stylelint'
 
 import { Linter } from '@Types/lint'
 import { colourLog } from '@Utils/colour-log'
@@ -15,7 +15,7 @@ const loadConfig = async (filePath?: string): Promise<Config | undefined> => {
     const searchPath = filePath
       ? path.resolve(filePath)
       : path.join(process.cwd(), 'style.css')
-    const customConfig = await resolveConfig(searchPath)
+    const customConfig = await stylelint.resolveConfig(searchPath)
     if (customConfig) {
       colourLog.configDebug(`Using custom ${Linter.Stylelint} config:`, customConfig)
       return undefined // Stylelint will auto-discover it

--- a/src/linters/stylelint/load-config.ts
+++ b/src/linters/stylelint/load-config.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 import stylelint from 'stylelint'
 
 import { Linter } from '@Types/lint'
@@ -12,22 +10,23 @@ import type { Config } from 'stylelint'
 const loadConfig = async (filePath?: string): Promise<Config | undefined> => {
   try {
     // Custom config
-    const searchPath = filePath
-      ? path.resolve(filePath)
-      : path.join(process.cwd(), 'style.css')
-    const customConfig = await stylelint.resolveConfig(searchPath)
-    if (customConfig) {
-      colourLog.configDebug(`Using custom ${Linter.Stylelint} config:`, customConfig)
-      return undefined // Stylelint will auto-discover it
+    if (filePath) {
+      const customConfig = await stylelint.resolveConfig(filePath)
+      if (customConfig) {
+        colourLog.configDebug(`Using custom ${Linter.Stylelint} config:`, customConfig)
+        return undefined // Stylelint will auto-discover it
+      }
     }
-
-    // Default config
-    colourLog.configDebug(`Using default ${Linter.Stylelint} config:`, defaultConfig)
-    return defaultConfig
   } catch (error) {
-    colourLog.error(`An error occurred while loading the ${Linter.Stylelint} config`, error)
-    process.exit(1)
+    if (!(error instanceof Error && error.name === 'ConfigurationError')) {
+      colourLog.error(`An error occurred while loading the ${Linter.Stylelint} config`, error)
+      process.exit(1)
+    }
   }
+
+  // Default config
+  colourLog.configDebug(`Using default ${Linter.Stylelint} config:`, defaultConfig)
+  return defaultConfig
 }
 
 export {

--- a/src/linters/stylelint/process-results.ts
+++ b/src/linters/stylelint/process-results.ts
@@ -6,9 +6,7 @@ import { formatResult } from '@Utils/format-result'
 import type { LintResult, RuleMeta } from 'stylelint'
 import type { LintReport, ReportResults, ReportSummary } from '@Types/lint'
 
-type RuleMetadata = { [ruleName: string]: Partial<RuleMeta> }
-
-const processResults = (results: Array<LintResult>, ruleMetadata: RuleMetadata): LintReport => {
+const processResults = (results: Array<LintResult>, ruleMetadata: Record<string, Partial<RuleMeta>>): LintReport => {
   const reportResults: ReportResults = {}
   const reportSummary: ReportSummary = {
     deprecatedRules: [],

--- a/src/linters/stylelint/resolve-config.ts
+++ b/src/linters/stylelint/resolve-config.ts
@@ -1,17 +1,15 @@
+import { createRequire } from 'node:module'
+
 import stylelint from 'stylelint'
 
 import { Linter } from '@Types/lint'
 import { colourLog } from '@Utils/colour-log'
 
-import defaultConfig from '../../../config/stylelint.config'
-
-import type { Config } from 'stylelint'
-
-const loadConfig = async (filePath?: string): Promise<Config | undefined> => {
+const resolveConfigFile = async (cssFilePath?: string): Promise<string | undefined> => {
   try {
     // Custom config
-    if (filePath) {
-      const customConfig = await stylelint.resolveConfig(filePath)
+    if (cssFilePath) {
+      const customConfig = await stylelint.resolveConfig(cssFilePath)
       if (customConfig) {
         colourLog.configDebug(`Using custom ${Linter.Stylelint} config:`, customConfig)
         return undefined // Stylelint will auto-discover it
@@ -25,10 +23,12 @@ const loadConfig = async (filePath?: string): Promise<Config | undefined> => {
   }
 
   // Default config
-  colourLog.configDebug(`Using default ${Linter.Stylelint} config:`, defaultConfig)
-  return defaultConfig
+  const require = createRequire(import.meta.url)
+  const defaultConfigPath = require.resolve('./stylelint.config')
+  colourLog.configDebug(`Using default ${Linter.Stylelint} config:`, defaultConfigPath)
+  return defaultConfigPath
 }
 
 export {
-  loadConfig,
+  resolveConfigFile,
 }

--- a/src/utils/__tests__/colour-log.spec.ts
+++ b/src/utils/__tests__/colour-log.spec.ts
@@ -40,7 +40,7 @@ describe('colourLog', () => {
 
   describe('configDebug', () => {
 
-    it('does not log if global.debug is false', () => {
+    it('does not log if `global.debug` is false', () => {
       global.debug = false
 
       colourLog.configDebug('Debug message', 'config')
@@ -49,7 +49,7 @@ describe('colourLog', () => {
       expect(mockConsoleLog).not.toHaveBeenCalled()
     })
 
-    it('logs the message in blue and the config in default if global.debug is true', () => {
+    it('logs the message in blue and the config in default if `global.debug` is true', () => {
       global.debug = true
 
       colourLog.configDebug('Debug message', 'config')
@@ -74,14 +74,14 @@ describe('colourLog', () => {
       expect(mockConsoleError).toHaveBeenCalledOnceWith('\n× An error occurred.')
     })
 
-    it('logs the text with debug instructions if there is an error and global.debug is false', () => {
+    it('logs the text with debug instructions if there is an error and `global.debug` is false', () => {
       colourLog.error('An error occurred', error)
 
       expect(chalk.red).toHaveBeenCalledOnceWith('\n× An error occurred. Run with --debug for more information.')
       expect(mockConsoleError).toHaveBeenCalledOnceWith('\n× An error occurred. Run with --debug for more information.')
     })
 
-    it('logs the error if global.debug is true', () => {
+    it('logs the error if `global.debug` is true', () => {
       global.debug = true
 
       colourLog.error('An error occurred', error)

--- a/src/utils/__tests__/source-files.spec.ts
+++ b/src/utils/__tests__/source-files.spec.ts
@@ -34,7 +34,7 @@ describe('sourceFiles', () => {
     [Linter.ESLint, ['**/*.ts']],
     [Linter.Markdownlint, ['**/*.md']],
     [Linter.Stylelint, ['**/*.css']],
-  ])('calls glob with the correct patterns and options', async (linter, expectedFilePattern) => {
+  ])('calls glob with the patterns and options for %s', async (linter, expectedFilePattern) => {
     expect.assertions(1)
 
     jest.mocked(glob).mockResolvedValue([])

--- a/src/utils/__tests__/terminal.spec.ts
+++ b/src/utils/__tests__/terminal.spec.ts
@@ -2,7 +2,7 @@ import { clearTerminal } from '../terminal'
 
 describe('clearTerminal', () => {
 
-  it('calls process.stdout.write to clear the terminal', () => {
+  it('calls `process.stdout.write` to clear the terminal', () => {
     const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
     clearTerminal()

--- a/stylelint.config.ts
+++ b/stylelint.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from 'stylelint'
+
+export default {
+  rules: {
+    'no-empty-source': true,
+  },
+} satisfies Config

--- a/yarn.lock
+++ b/yarn.lock
@@ -658,6 +658,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cacheable/memory@npm:^2.0.8":
+  version: 2.0.9
+  resolution: "@cacheable/memory@npm:2.0.9"
+  dependencies:
+    "@cacheable/utils": "npm:^2.4.1"
+    "@keyv/bigmap": "npm:^1.3.1"
+    hookified: "npm:^1.15.1"
+    keyv: "npm:^5.6.0"
+  checksum: 10c0/2261439b76ddeb1c486c1c6a5a5598da2ff3f909b961a7315d0af72f645ecbce701f4ad8767c94c2a7e674bef7bd6afa40f12cb8ce5895f69cf69aa121c04462
+  languageName: node
+  linkType: hard
+
+"@cacheable/utils@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "@cacheable/utils@npm:2.4.1"
+  dependencies:
+    hashery: "npm:^1.5.1"
+    keyv: "npm:^5.6.0"
+  checksum: 10c0/ca2af47636ed27ab26dfedf12add639f42b90c289ecd5d816fb7a299074d9df463751745a83abfb81f6236a70c8ea40f0902e984869638a5ca3a7274e203f987
+  languageName: node
+  linkType: hard
+
 "@changesets/apply-release-plan@npm:^7.0.14":
   version: 7.0.14
   resolution: "@changesets/apply-release-plan@npm:7.0.14"
@@ -901,6 +923,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@csstools/css-calc@npm:^3.2.0":
+  version: 3.2.1
+  resolution: "@csstools/css-calc@npm:3.2.1"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^4.0.0
+    "@csstools/css-tokenizer": ^4.0.0
+  checksum: 10c0/0191c8d1cd4dffa0d3b6bfd1e78a721934b1d7a6c972966e4fdaa72208c6789e8ff443ee81764a32f1e6107825695b5524ef2b4dc1681b5b29230f2a1277e5df
+  languageName: node
+  linkType: hard
+
 "@csstools/css-parser-algorithms@npm:^3.0.0, @csstools/css-parser-algorithms@npm:^3.0.1":
   version: 3.0.1
   resolution: "@csstools/css-parser-algorithms@npm:3.0.1"
@@ -910,10 +942,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@csstools/css-parser-algorithms@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@csstools/css-parser-algorithms@npm:4.0.0"
+  peerDependencies:
+    "@csstools/css-tokenizer": ^4.0.0
+  checksum: 10c0/94558c2428d6ef0ddef542e86e0a8376aa1263a12a59770abb13ba50d7b83086822c75433f32aa2e7fef00555e1cc88292f9ca5bce79aed232bb3fed73b1528d
+  languageName: node
+  linkType: hard
+
+"@csstools/css-syntax-patches-for-csstree@npm:^1.1.3":
+  version: 1.1.4
+  resolution: "@csstools/css-syntax-patches-for-csstree@npm:1.1.4"
+  peerDependencies:
+    css-tree: ^3.2.1
+  peerDependenciesMeta:
+    css-tree:
+      optional: true
+  checksum: 10c0/3872a7befb553c53249c87e964ac00f55d059f4574d2cc023e03e1dafc86a5ad19f6a6d05fa2c14fb192e6a4538a73158104cc2e32e0688f27fd841b9ba76568
+  languageName: node
+  linkType: hard
+
 "@csstools/css-tokenizer@npm:^3.0.0, @csstools/css-tokenizer@npm:^3.0.1":
   version: 3.0.1
   resolution: "@csstools/css-tokenizer@npm:3.0.1"
   checksum: 10c0/c9ed4373e5731b5375ea9791590081019c04e95f08b46b272977e5e7b8c3d560affc62e82263cb8def1df1e57f0673140e7e16a14a5e7be04e6a234be088d1d3
+  languageName: node
+  linkType: hard
+
+"@csstools/css-tokenizer@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@csstools/css-tokenizer@npm:4.0.0"
+  checksum: 10c0/669cf3d0f9c8e1ffdf8c9955ad8beba0c8cfe03197fe29a4fcbd9ee6f7a18856cfa42c62670021a75183d9ab37f5d14a866e6a9df753a6c07f59e36797a9ea9f
   languageName: node
   linkType: hard
 
@@ -927,12 +987,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@csstools/media-query-list-parser@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@csstools/media-query-list-parser@npm:5.0.0"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^4.0.0
+    "@csstools/css-tokenizer": ^4.0.0
+  checksum: 10c0/dbc22654769eca02c182f3a57be02cd5b8d0b958adc8397e66770b64b0e8fcd32faa93a3f6a99e1457bde11862485de3cd83a31dac7b03925d32f9891b31ccfd
+  languageName: node
+  linkType: hard
+
+"@csstools/selector-resolve-nested@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@csstools/selector-resolve-nested@npm:4.0.0"
+  peerDependencies:
+    postcss-selector-parser: ^7.1.1
+  checksum: 10c0/f6bccfe24a47c3e55710d421740550b868bbe7f0820f32d14d1eb737eefe7ec26261fb726cc5cfdf8236b3173d0a657ebdc9602e0c53824603f719b14a76bcaf
+  languageName: node
+  linkType: hard
+
 "@csstools/selector-specificity@npm:^4.0.0":
   version: 4.0.0
   resolution: "@csstools/selector-specificity@npm:4.0.0"
   peerDependencies:
     postcss-selector-parser: ^6.1.0
   checksum: 10c0/6f4d4ecfdcd37f950100de8ffe0b4c1b1cc8c004aab2c2ebaa5c3e2bca2412d15b17d4628435f47a62d2c56db41bcbf985cb9c69e74b89964d48e421e93e75ba
+  languageName: node
+  linkType: hard
+
+"@csstools/selector-specificity@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@csstools/selector-specificity@npm:6.0.0"
+  peerDependencies:
+    postcss-selector-parser: ^7.1.1
+  checksum: 10c0/7a93973f9054f2e1f03c8543cde68e0b0c65e5e72da6e4e959974d28fe809e11bd2afa1ff2ca11a1690a4c9a2f2bbe00d00e2b07fb2108bf89c5e48fe441c432
   languageName: node
   linkType: hard
 
@@ -1694,6 +1782,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@keyv/bigmap@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@keyv/bigmap@npm:1.3.1"
+  dependencies:
+    hashery: "npm:^1.4.0"
+    hookified: "npm:^1.15.0"
+  peerDependencies:
+    keyv: ^5.6.0
+  checksum: 10c0/acc6a4a5edf462ce23e95672ab4bfaf7cd1941dff6bf3a2f671ce467961ace1fac9d3eb75a9ed9a8e92012e00a7d8b16ad1677bc539a52c3ad0cec31473e2349
+  languageName: node
+  linkType: hard
+
+"@keyv/serialize@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@keyv/serialize@npm:1.1.1"
+  checksum: 10c0/b0008cae4a54400c3abf587b8cc2474c6f528ee58969ce6cf9cb07a04006f80c73c85971d6be6544408318a2bc40108236a19a82aea0a6de95aae49533317374
+  languageName: node
+  linkType: hard
+
 "@manypkg/find-root@npm:^1.1.0":
   version: 1.1.0
   resolution: "@manypkg/find-root@npm:1.1.0"
@@ -2209,6 +2316,13 @@ __metadata:
   version: 0.34.47
   resolution: "@sinclair/typebox@npm:0.34.47"
   checksum: 10c0/ebe923fe2c26900982634e5639a00471da0b182eee61a5a0436cd1df174f90c5b0fcd7507cc21ad2fca3c326aee387487040badc723bc2599a09bc3e9be09b38
+  languageName: node
+  linkType: hard
+
+"@sindresorhus/merge-streams@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@sindresorhus/merge-streams@npm:4.0.0"
+  checksum: 10c0/482ee543629aa1933b332f811a1ae805a213681ecdd98c042b1c1b89387df63e7812248bb4df3910b02b3cc5589d3d73e4393f30e197c9dde18046ccd471fc6b
   languageName: node
   linkType: hard
 
@@ -2816,6 +2930,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "ansi-regex@npm:6.2.2"
+  checksum: 10c0/05d4acb1d2f59ab2cf4b794339c7b168890d44dda4bf0ce01152a8da0213aca207802f930442ce8cd22d7a92f44907664aac6508904e75e038fa944d2601b30f
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
@@ -3112,6 +3233,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cacheable@npm:^2.3.4":
+  version: 2.3.5
+  resolution: "cacheable@npm:2.3.5"
+  dependencies:
+    "@cacheable/memory": "npm:^2.0.8"
+    "@cacheable/utils": "npm:^2.4.1"
+    hookified: "npm:^1.15.0"
+    keyv: "npm:^5.6.0"
+    qified: "npm:^0.10.1"
+  checksum: 10c0/a52f06df2c97cf2757c3c608adfcdee6a7bde2bb7ee7772205c2dd72d5ed7b149bd482538cf9c4fd0871b124cd0772a5eaba2e56d5f87e339cf2082795c6c9cf
+  languageName: node
+  linkType: hard
+
 "callsites@npm:^3.0.0, callsites@npm:^3.1.0":
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
@@ -3380,6 +3514,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmiconfig@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "cosmiconfig@npm:9.0.1"
+  dependencies:
+    env-paths: "npm:^2.2.1"
+    import-fresh: "npm:^3.3.0"
+    js-yaml: "npm:^4.1.0"
+    parse-json: "npm:^5.2.0"
+  peerDependencies:
+    typescript: ">=4.9.5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/a5d4d95599687532ee072bca60170133c24d4e08cd795529e0f22c6ce5fde9409eaf4f26e36e3d671f43270ef858fc68f3c7b0ec28e58fac7ddebda5b7725306
+  languageName: node
+  linkType: hard
+
 "create-require@npm:^1.1.0":
   version: 1.1.1
   resolution: "create-require@npm:1.1.1"
@@ -3416,6 +3567,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-functions-list@npm:^3.3.3":
+  version: 3.3.3
+  resolution: "css-functions-list@npm:3.3.3"
+  checksum: 10c0/7b9e5dd94e0178b2edb0f3263de5ae7942e56ab0b73420d4adb8fea003367e1dbc94fe8ea300bf732d1423f7eafb523e695136f0a4e6ae4f0abec66848219ee6
+  languageName: node
+  linkType: hard
+
 "css-property-sort-order-smacss@npm:~2.2.0":
   version: 2.2.0
   resolution: "css-property-sort-order-smacss@npm:2.2.0"
@@ -3430,6 +3588,16 @@ __metadata:
     mdn-data: "npm:2.0.30"
     source-map-js: "npm:^1.0.1"
   checksum: 10c0/6f8c1a11d5e9b14bf02d10717fc0351b66ba12594166f65abfbd8eb8b5b490dd367f5c7721db241a3c792d935fc6751fbc09f7e1598d421477ad9fadc30f4f24
+  languageName: node
+  linkType: hard
+
+"css-tree@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "css-tree@npm:3.2.1"
+  dependencies:
+    mdn-data: "npm:2.27.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/1f65e9ccaa56112a4706d6f003dd43d777f0dbcf848e66fd320f823192533581f8dd58daa906cb80622658332d50284d6be13b87a6ab4556cbbfe9ef535bbf7e
   languageName: node
   linkType: hard
 
@@ -3454,7 +3622,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.0.0":
+"debug@npm:^4.0.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -4198,6 +4366,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-entry-cache@npm:^11.1.3":
+  version: 11.1.3
+  resolution: "file-entry-cache@npm:11.1.3"
+  dependencies:
+    flat-cache: "npm:^6.1.22"
+  checksum: 10c0/a0b478e576f055fdf548665677660eec876a1b25b0b5509e9d0ea9bd4a7fb59270d9c7084f28d914717c5f1c29cd502116fcba24f6de2cea7634bb57c267d347
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^8.0.0":
   version: 8.0.0
   resolution: "file-entry-cache@npm:8.0.0"
@@ -4265,10 +4442,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"flat-cache@npm:^6.1.22":
+  version: 6.1.22
+  resolution: "flat-cache@npm:6.1.22"
+  dependencies:
+    cacheable: "npm:^2.3.4"
+    flatted: "npm:^3.4.2"
+    hookified: "npm:^1.15.0"
+  checksum: 10c0/ec94fba4ecb10b43567bb815f19e178d4351a66a58117b06a06c81bda6b579c2ed75d8cbd9ea90a2ab9408493b564ffef55386f263f20d1d73bb991fa97de67f
+  languageName: node
+  linkType: hard
+
 "flatted@npm:^3.2.9, flatted@npm:^3.3.1":
   version: 3.3.1
   resolution: "flatted@npm:3.3.1"
   checksum: 10c0/324166b125ee07d4ca9bcf3a5f98d915d5db4f39d711fba640a3178b959919aae1f7cfd8aabcfef5826ed8aa8a2aa14cc85b2d7d18ff638ddf4ae3df39573eaf
+  languageName: node
+  linkType: hard
+
+"flatted@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
   languageName: node
   linkType: hard
 
@@ -4371,7 +4566,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-east-asian-width@npm:^1.3.0":
+"get-east-asian-width@npm:^1.3.0, get-east-asian-width@npm:^1.5.0":
   version: 1.6.0
   resolution: "get-east-asian-width@npm:1.6.0"
   checksum: 10c0/7e72e9550fd49ca5b246f9af6bb2afc129c96412845ff6556b3274fd44817a381702ca17028efe9866b261a3d44254cbf21e6c90cf05b4b61675630af776d431
@@ -4560,6 +4755,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globby@npm:^16.2.0":
+  version: 16.2.0
+  resolution: "globby@npm:16.2.0"
+  dependencies:
+    "@sindresorhus/merge-streams": "npm:^4.0.0"
+    fast-glob: "npm:^3.3.3"
+    ignore: "npm:^7.0.5"
+    is-path-inside: "npm:^4.0.0"
+    slash: "npm:^5.1.0"
+    unicorn-magic: "npm:^0.4.0"
+  checksum: 10c0/fc0675e01dc1da5095f30dccc46a3047fc38d45ca08c21c1aa871bd79d38682f507d84a159be168019db5fffaa09c5663c3679c29190a2d4f999dc91d7ff6406
+  languageName: node
+  linkType: hard
+
 "globjoin@npm:^0.1.4":
   version: 0.1.4
   resolution: "globjoin@npm:0.1.4"
@@ -4613,12 +4822,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-flag@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "has-flag@npm:5.0.1"
+  checksum: 10c0/6c214902e9d829979ef0f906980599df1db5ca289a9c72cc1b1ebc2c8c924681c60b632a21bfc23728a1098a3f300029a8608f293fcc559962ecd495652aa250
+  languageName: node
+  linkType: hard
+
+"hashery@npm:^1.4.0, hashery@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "hashery@npm:1.5.1"
+  dependencies:
+    hookified: "npm:^1.15.0"
+  checksum: 10c0/ab4225b655a7b0d05df99b1a59d5b3a51fe433f82422ca25e6f3f4c4ddd30adb49ebd38e0047ef9bded93319c1e9fc857e16aa382e554929c871cb77d39fc463
+  languageName: node
+  linkType: hard
+
 "hasown@npm:^2.0.0":
   version: 2.0.2
   resolution: "hasown@npm:2.0.2"
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"hookified@npm:^1.15.0, hookified@npm:^1.15.1":
+  version: 1.15.1
+  resolution: "hookified@npm:1.15.1"
+  checksum: 10c0/6b691374fa97ae57169fb29f90e723499fda5e85494654fbe55c4768b3ccbf3e14c0adc8d0f365f32c503b60d7c06f907781f5966c03d41c423575eb5e16860c
+  languageName: node
+  linkType: hard
+
+"hookified@npm:^2.1.1":
+  version: 2.2.0
+  resolution: "hookified@npm:2.2.0"
+  checksum: 10c0/7017d2b66945490293a5aba239e7b39f39071dd940fa019348c7ffea92b91b8c267853c4c51680ed0f3687b33352582fa4d2cff6dd4c5a1c5c44b037276f07aa
   languageName: node
   linkType: hard
 
@@ -4633,6 +4872,13 @@ __metadata:
   version: 3.3.1
   resolution: "html-tags@npm:3.3.1"
   checksum: 10c0/680165e12baa51bad7397452d247dbcc5a5c29dac0e6754b1187eee3bf26f514bc1907a431dd2f7eb56207611ae595ee76a0acc8eaa0d931e72c791dd6463d79
+  languageName: node
+  linkType: hard
+
+"html-tags@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "html-tags@npm:5.1.0"
+  checksum: 10c0/2dda19bc07e75837d0c52984558d92e8b82768050e4d6421b3164b1cb6ca5e73719209c2b23c0fa71faf097a7a3d18cf7f2021b488f1b1f270fca516c4c634c9
   languageName: node
   linkType: hard
 
@@ -4718,6 +4964,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ignore@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "ignore@npm:7.0.5"
+  checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
+  languageName: node
+  linkType: hard
+
 "import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
@@ -4737,6 +4990,13 @@ __metadata:
   bin:
     import-local-fixture: fixtures/cli.js
   checksum: 10c0/94cd6367a672b7e0cb026970c85b76902d2710a64896fa6de93bd5c571dd03b228c5759308959de205083e3b1c61e799f019c9e36ee8e9c523b993e1057f0433
+  languageName: node
+  linkType: hard
+
+"import-meta-resolve@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "import-meta-resolve@npm:4.2.0"
+  checksum: 10c0/3ee8aeecb61d19b49d2703987f977e9d1c7d4ba47db615a570eaa02fe414f40dfa63f7b953e842cbe8470d26df6371332bfcf21b2fd92b0112f9fea80dde2c4c
   languageName: node
   linkType: hard
 
@@ -4894,6 +5154,13 @@ __metadata:
   version: 3.0.3
   resolution: "is-path-inside@npm:3.0.3"
   checksum: 10c0/cf7d4ac35fb96bab6a1d2c3598fe5ebb29aafb52c0aaa482b5a3ed9d8ba3edc11631e3ec2637660c44b3ce0e61a08d54946e8af30dec0b60a7c27296c68ffd05
+  languageName: node
+  linkType: hard
+
+"is-path-inside@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-path-inside@npm:4.0.0"
+  checksum: 10c0/51188d7e2b1d907a9a5f7c18d99a90b60870b951ed87cf97595d9aaa429d4c010652c3350bcbf31182e7f4b0eab9a1860b43e16729b13cb1a44baaa6cdb64c46
   languageName: node
   linkType: hard
 
@@ -5709,6 +5976,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"keyv@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "keyv@npm:5.6.0"
+  dependencies:
+    "@keyv/serialize": "npm:^1.1.1"
+  checksum: 10c0/c3ea795b6e03593ca57c8f70928a69bad14c13389a7fb75649a115ff55615244b04d8902798d841c17f0bb4a8a8866c97133b543b93f151b440170bba09176db
+  languageName: node
+  linkType: hard
+
 "kind-of@npm:^6.0.2":
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
@@ -5910,6 +6186,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mathml-tag-names@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mathml-tag-names@npm:4.0.0"
+  checksum: 10c0/2e928554c61b5e502ee551a23bb4157b99ffd042578e28fb4038ee67d19ea2b1a79c34a3c2ab1611437f668f6b29436e1c8f6fdc20eaf3c88d511ce5b8954fe8
+  languageName: node
+  linkType: hard
+
 "mdn-data@npm:2.0.30":
   version: 2.0.30
   resolution: "mdn-data@npm:2.0.30"
@@ -5917,10 +6200,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdn-data@npm:2.27.1":
+  version: 2.27.1
+  resolution: "mdn-data@npm:2.27.1"
+  checksum: 10c0/eb8abf5d22e4d1e090346f5e81b67d23cef14c83940e445da5c44541ad874dc8fb9f6ca236e8258c3a489d9fb5884188a4d7d58773adb9089ac2c0b966796393
+  languageName: node
+  linkType: hard
+
 "meow@npm:^13.2.0":
   version: 13.2.0
   resolution: "meow@npm:13.2.0"
   checksum: 10c0/d5b339ae314715bcd0b619dd2f8a266891928e21526b4800d49b4fba1cc3fff7e2c1ff5edd3344149fac841bc2306157f858e8c4d5eaee4d52ce52ad925664ce
+  languageName: node
+  linkType: hard
+
+"meow@npm:^14.1.0":
+  version: 14.1.0
+  resolution: "meow@npm:14.1.0"
+  checksum: 10c0/f0ca4bb4fd08e4b9470fcbb7332deb61d72d40d4bda18ffb87c1a98e5014c0b44749ae9f0cab18fa532e26d61cef5d453831f9ae23ac09fa8ea0e0469be73ebc
   languageName: node
   linkType: hard
 
@@ -6397,6 +6694,15 @@ __metadata:
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.12":
+  version: 3.3.12
+  resolution: "nanoid@npm:3.3.12"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
   languageName: node
   linkType: hard
 
@@ -6903,6 +7209,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-safe-parser@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "postcss-safe-parser@npm:7.0.1"
+  peerDependencies:
+    postcss: ^8.4.31
+  checksum: 10c0/6957b10b818bd8d4664ec0e548af967f7549abedfb37f844d389571d36af681340f41f9477b9ccf34bcc7599bdef222d1d72e79c64373001fae77089fba6d965
+  languageName: node
+  linkType: hard
+
 "postcss-scss@npm:4.0.9":
   version: 4.0.9
   resolution: "postcss-scss@npm:4.0.9"
@@ -6929,6 +7244,16 @@ __metadata:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
   checksum: 10c0/523196a6bd8cf660bdf537ad95abd79e546d54180f9afb165a4ab3e651ac705d0f8b8ce6b3164fb9e3279ce482c5f751a69eb2d3a1e8eb0fd5e82294fb3ef13e
+  languageName: node
+  linkType: hard
+
+"postcss-selector-parser@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "postcss-selector-parser@npm:7.1.1"
+  dependencies:
+    cssesc: "npm:^3.0.0"
+    util-deprecate: "npm:^1.0.2"
+  checksum: 10c0/02d3b1589ddcddceed4b583b098b95a7266dacd5135f041e5d913ebb48e874fd333a36e564cc9a2ec426a464cb18db11cb192ac76247aced5eba8c951bf59507
   languageName: node
   linkType: hard
 
@@ -6967,6 +7292,17 @@ __metadata:
     picocolors: "npm:^1.0.1"
     source-map-js: "npm:^1.2.0"
   checksum: 10c0/ad6f8b9b1157d678560373696109745ab97a947d449f8a997acac41c7f1e4c0f3ca4b092d6df1387f430f2c9a319987b1780dbdc27e35800a88cde9b606c1e8f
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.14":
+  version: 8.5.15
+  resolution: "postcss@npm:8.5.15"
+  dependencies:
+    nanoid: "npm:^3.3.12"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
   languageName: node
   linkType: hard
 
@@ -7044,6 +7380,15 @@ __metadata:
   version: 7.0.1
   resolution: "pure-rand@npm:7.0.1"
   checksum: 10c0/9cade41030f5ec95f5d55a11a71404cd6f46b69becaad892097cd7f58e2c6248cd0a933349ca7d21336ab629f1da42ffe899699b671bc4651600eaf6e57f837e
+  languageName: node
+  linkType: hard
+
+"qified@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "qified@npm:0.10.1"
+  dependencies:
+    hookified: "npm:^2.1.1"
+  checksum: 10c0/4a39d45492c65a4b9795381acede1bd566028ce9764ead5b41d776b391a898bf0855dd2b59d724a6711fe253ba3cacf7c9a8832887cf9dc6d48a2c5e4997c82d
   languageName: node
   linkType: hard
 
@@ -7424,6 +7769,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"slash@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "slash@npm:5.1.0"
+  checksum: 10c0/eb48b815caf0bdc390d0519d41b9e0556a14380f6799c72ba35caf03544d501d18befdeeef074bc9c052acf69654bc9e0d79d7f1de0866284137a40805299eb3
+  languageName: node
+  linkType: hard
+
 "slice-ansi@npm:^4.0.0":
   version: 4.0.0
   resolution: "slice-ansi@npm:4.0.0"
@@ -7481,6 +7833,13 @@ __metadata:
   version: 1.2.0
   resolution: "source-map-js@npm:1.2.0"
   checksum: 10c0/7e5f896ac10a3a50fe2898e5009c58ff0dc102dcb056ed27a354623a0ece8954d4b2649e1a1b2b52ef2e161d26f8859c7710350930751640e71e374fe2d321a4
+  languageName: node
+  linkType: hard
+
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
   languageName: node
   linkType: hard
 
@@ -7604,6 +7963,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width@npm:^8.2.1":
+  version: 8.2.1
+  resolution: "string-width@npm:8.2.1"
+  dependencies:
+    get-east-asian-width: "npm:^1.5.0"
+    strip-ansi: "npm:^7.1.2"
+  checksum: 10c0/d467b4eaf4c40a01bb438a2620e77badd2456ffd5131c9973abe4f3acf7c802d5b21f3b6a00a5e33a7fc28ca8f9c103226e01bac61e9f259659c6f46d78e353a
+  languageName: node
+  linkType: hard
+
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
@@ -7619,6 +7988,15 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10c0/a198c3762e8832505328cbf9e8c8381de14a4fa50a4f9b2160138158ea88c0f5549fb50cb13c651c3088f47e63a108b34622ec18c0499b6c8c3a5ddf6b305ac4
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.1.2":
+  version: 7.2.0
+  resolution: "strip-ansi@npm:7.2.0"
+  dependencies:
+    ansi-regex: "npm:^6.2.2"
+  checksum: 10c0/544d13b7582f8254811ea97db202f519e189e59d35740c46095897e254e4f1aa9fe1524a83ad6bc5ad67d4dd6c0281d2e0219ed62b880a6238a16a17d375f221
   languageName: node
   linkType: hard
 
@@ -7714,7 +8092,52 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint@npm:16.9.0, stylelint@npm:^16.8.2":
+"stylelint@npm:17.12.0":
+  version: 17.12.0
+  resolution: "stylelint@npm:17.12.0"
+  dependencies:
+    "@csstools/css-calc": "npm:^3.2.0"
+    "@csstools/css-parser-algorithms": "npm:^4.0.0"
+    "@csstools/css-syntax-patches-for-csstree": "npm:^1.1.3"
+    "@csstools/css-tokenizer": "npm:^4.0.0"
+    "@csstools/media-query-list-parser": "npm:^5.0.0"
+    "@csstools/selector-resolve-nested": "npm:^4.0.0"
+    "@csstools/selector-specificity": "npm:^6.0.0"
+    colord: "npm:^2.9.3"
+    cosmiconfig: "npm:^9.0.1"
+    css-functions-list: "npm:^3.3.3"
+    css-tree: "npm:^3.2.1"
+    debug: "npm:^4.4.3"
+    fast-glob: "npm:^3.3.3"
+    fastest-levenshtein: "npm:^1.0.16"
+    file-entry-cache: "npm:^11.1.3"
+    global-modules: "npm:^2.0.0"
+    globby: "npm:^16.2.0"
+    globjoin: "npm:^0.1.4"
+    html-tags: "npm:^5.1.0"
+    ignore: "npm:^7.0.5"
+    import-meta-resolve: "npm:^4.2.0"
+    mathml-tag-names: "npm:^4.0.0"
+    meow: "npm:^14.1.0"
+    micromatch: "npm:^4.0.8"
+    normalize-path: "npm:^3.0.0"
+    picocolors: "npm:^1.1.1"
+    postcss: "npm:^8.5.14"
+    postcss-safe-parser: "npm:^7.0.1"
+    postcss-selector-parser: "npm:^7.1.1"
+    postcss-value-parser: "npm:^4.2.0"
+    string-width: "npm:^8.2.1"
+    supports-hyperlinks: "npm:^4.4.0"
+    svg-tags: "npm:^1.0.0"
+    table: "npm:^6.9.0"
+    write-file-atomic: "npm:^7.0.1"
+  bin:
+    stylelint: bin/stylelint.mjs
+  checksum: 10c0/fdc066ebf923168cfaf2927f3d2b222fd0cf12722610c2d80fbd395714ccfa108e9319f5fccb422fa4dff5d08f39543ed6ad1f1511172de4709364f09b4ea177
+  languageName: node
+  linkType: hard
+
+"stylelint@npm:^16.8.2":
   version: 16.9.0
   resolution: "stylelint@npm:16.9.0"
   dependencies:
@@ -7763,6 +8186,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"supports-color@npm:^10.2.2":
+  version: 10.2.2
+  resolution: "supports-color@npm:10.2.2"
+  checksum: 10c0/fb28dd7e0cdf80afb3f2a41df5e068d60c8b4f97f7140de2eaed5b42e075d82a0e980b20a2c0efd2b6d73cfacb55555285d8cc719fa0472220715aefeaa1da7c
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^5.3.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
@@ -7800,6 +8230,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"supports-hyperlinks@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "supports-hyperlinks@npm:4.4.0"
+  dependencies:
+    has-flag: "npm:^5.0.1"
+    supports-color: "npm:^10.2.2"
+  checksum: 10c0/1172347b736e52f012506e162d5782d5fe9c64e22d286bd6daffbd182ca5696cc341fb0f66a550e2b96b5cdf31fc5217b009c6b92150843585debc6d8f1697bd
+  languageName: node
+  linkType: hard
+
 "supports-preserve-symlinks-flag@npm:^1.0.0":
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
@@ -7833,6 +8273,19 @@ __metadata:
     string-width: "npm:^4.2.3"
     strip-ansi: "npm:^6.0.1"
   checksum: 10c0/f8b348af38ee34e419d8ce7306ba00671ce6f20e861ccff22555f491ba264e8416086063ce278a8d81abfa8d23b736ec2cca7ac4029b5472f63daa4b4688b803
+  languageName: node
+  linkType: hard
+
+"table@npm:^6.9.0":
+  version: 6.9.0
+  resolution: "table@npm:6.9.0"
+  dependencies:
+    ajv: "npm:^8.0.1"
+    lodash.truncate: "npm:^4.4.2"
+    slice-ansi: "npm:^4.0.0"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/35646185712bb65985fbae5975dda46696325844b78735f95faefae83e86df0a265277819a3e67d189de6e858c509b54e66ca3958ffd51bde56ef1118d455bf4
   languageName: node
   linkType: hard
 
@@ -8112,6 +8565,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unicorn-magic@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "unicorn-magic@npm:0.4.0"
+  checksum: 10c0/cd6eff90967a5528dfa2016bdb5b38b0cd64c8558f9ba04fb5c2c23f3a232a67dfe2bfa4c45af3685d5f1a40dbac6a36d48e053f80f97ae4da1e0f6a55431685
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^4.0.0":
   version: 4.0.0
   resolution: "unique-filename@npm:4.0.0"
@@ -8377,6 +8837,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"write-file-atomic@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "write-file-atomic@npm:7.0.1"
+  dependencies:
+    signal-exit: "npm:^4.0.1"
+  checksum: 10c0/69cebb64945e22928a24ae7e2a55bf54438c92d6f657c1fa5e96b7c7a50f6c022e7454ab5c259079bb35f60296242f3a21234c79320d64a8ad57675b56a2098d
+  languageName: node
+  linkType: hard
+
 "y18n@npm:^5.0.5":
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
@@ -8477,7 +8946,7 @@ __metadata:
     rollup: "npm:4.55.1"
     rollup-plugin-copy: "npm:3.5.0"
     space-log: "npm:2.0.0"
-    stylelint: "npm:16.9.0"
+    stylelint: "npm:17.12.0"
     stylelint-config-property-sort-order-smacss: "npm:10.0.0"
     stylelint-declaration-strict-value: "npm:1.10.6"
     stylelint-order: "npm:6.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,12 +933,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/css-parser-algorithms@npm:^3.0.0, @csstools/css-parser-algorithms@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@csstools/css-parser-algorithms@npm:3.0.1"
+"@csstools/css-parser-algorithms@npm:^3.0.0, @csstools/css-parser-algorithms@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "@csstools/css-parser-algorithms@npm:3.0.5"
   peerDependencies:
-    "@csstools/css-tokenizer": ^3.0.1
-  checksum: 10c0/064c6d519197b5af43bbf5efe8f4cdbd361b006113aa82160d637e925b50c643a52d33d512ca01c63042d952d723a2a10798231a714668356b76668fb11294e3
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 10c0/d9a1c888bd43849ae3437ca39251d5c95d2c8fd6b5ccdb7c45491dfd2c1cbdc3075645e80901d120e4d2c1993db9a5b2d83793b779dbbabcfb132adb142eb7f7
   languageName: node
   linkType: hard
 
@@ -951,7 +951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/css-syntax-patches-for-csstree@npm:^1.1.3":
+"@csstools/css-syntax-patches-for-csstree@npm:^1.0.19, @csstools/css-syntax-patches-for-csstree@npm:^1.1.3":
   version: 1.1.4
   resolution: "@csstools/css-syntax-patches-for-csstree@npm:1.1.4"
   peerDependencies:
@@ -963,10 +963,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/css-tokenizer@npm:^3.0.0, @csstools/css-tokenizer@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@csstools/css-tokenizer@npm:3.0.1"
-  checksum: 10c0/c9ed4373e5731b5375ea9791590081019c04e95f08b46b272977e5e7b8c3d560affc62e82263cb8def1df1e57f0673140e7e16a14a5e7be04e6a234be088d1d3
+"@csstools/css-tokenizer@npm:^3.0.0, @csstools/css-tokenizer@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@csstools/css-tokenizer@npm:3.0.4"
+  checksum: 10c0/3b589f8e9942075a642213b389bab75a2d50d05d203727fcdac6827648a5572674caff07907eff3f9a2389d86a4ee47308fafe4f8588f4a77b7167c588d2559f
   languageName: node
   linkType: hard
 
@@ -977,13 +977,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/media-query-list-parser@npm:^3.0.0, @csstools/media-query-list-parser@npm:^3.0.1":
+"@csstools/media-query-list-parser@npm:^3.0.0":
   version: 3.0.1
   resolution: "@csstools/media-query-list-parser@npm:3.0.1"
   peerDependencies:
     "@csstools/css-parser-algorithms": ^3.0.1
     "@csstools/css-tokenizer": ^3.0.1
   checksum: 10c0/fca1935cabf9fb94128da87f72c34aa2cfce8eb0beba4c78d685c7b42aaba3521067710afc6905b7347fc41fe53947536ce15a7ef3387b48763d8f7d71778d5e
+  languageName: node
+  linkType: hard
+
+"@csstools/media-query-list-parser@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "@csstools/media-query-list-parser@npm:4.0.3"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^3.0.5
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 10c0/e29d856d57e9a036694662163179fc061a99579f05e7c3c35438b3e063790ae8a9ee9f1fb4b4693d8fc7672ae0801764fe83762ab7b9df2921fcc6172cfd5584
   languageName: node
   linkType: hard
 
@@ -1006,12 +1016,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/selector-specificity@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@csstools/selector-specificity@npm:4.0.0"
+"@csstools/selector-specificity@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@csstools/selector-specificity@npm:5.0.0"
   peerDependencies:
-    postcss-selector-parser: ^6.1.0
-  checksum: 10c0/6f4d4ecfdcd37f950100de8ffe0b4c1b1cc8c004aab2c2ebaa5c3e2bca2412d15b17d4628435f47a62d2c56db41bcbf985cb9c69e74b89964d48e421e93e75ba
+    postcss-selector-parser: ^7.0.0
+  checksum: 10c0/186b444cabcdcdeb553bfe021f80c58bfe9ef38dcc444f2b1f34a5aab9be063ab4e753022b2d5792049c041c28cfbb78e4b707ec398459300e402030d35c07eb
   languageName: node
   linkType: hard
 
@@ -1024,10 +1034,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dual-bundle/import-meta-resolve@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@dual-bundle/import-meta-resolve@npm:4.1.0"
-  checksum: 10c0/55069e550ee2710e738dd8bbd34aba796cede456287454b50c3be46fbef8695d00625677f3f41f5ffbec1174c0f57f314da9a908388bc9f8ad41a8438db884d9
+"@dual-bundle/import-meta-resolve@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@dual-bundle/import-meta-resolve@npm:4.2.1"
+  checksum: 10c0/8f1e572c14c4d20ea35734635085213abd13bd440c251309cf8ae5ed1082f6759cefa1c2c52a631f76859c57e26062f78a8cee4acc239c0edc87cd316a5d3b5b
   languageName: node
   linkType: hard
 
@@ -3506,24 +3516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "cosmiconfig@npm:9.0.0"
-  dependencies:
-    env-paths: "npm:^2.2.1"
-    import-fresh: "npm:^3.3.0"
-    js-yaml: "npm:^4.1.0"
-    parse-json: "npm:^5.2.0"
-  peerDependencies:
-    typescript: ">=4.9.5"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10c0/1c1703be4f02a250b1d6ca3267e408ce16abfe8364193891afc94c2d5c060b69611fdc8d97af74b7e6d5d1aac0ab2fb94d6b079573146bc2d756c2484ce5f0ee
-  languageName: node
-  linkType: hard
-
-"cosmiconfig@npm:^9.0.1":
+"cosmiconfig@npm:^9.0.0, cosmiconfig@npm:^9.0.1":
   version: 9.0.1
   resolution: "cosmiconfig@npm:9.0.1"
   dependencies:
@@ -3569,14 +3562,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-functions-list@npm:^3.2.2":
-  version: 3.2.2
-  resolution: "css-functions-list@npm:3.2.2"
-  checksum: 10c0/8638a63d0cf1bdc50d4a752ec1c94a57e9953c3b03eace4f5526db20bec3c061e95089f905dbb4999c44b9780ce777ba856967560f6d15119a303f6030901c10
-  languageName: node
-  linkType: hard
-
-"css-functions-list@npm:^3.3.3":
+"css-functions-list@npm:^3.2.3, css-functions-list@npm:^3.3.3":
   version: 3.3.3
   resolution: "css-functions-list@npm:3.3.3"
   checksum: 10c0/7b9e5dd94e0178b2edb0f3263de5ae7942e56ab0b73420d4adb8fea003367e1dbc94fe8ea300bf732d1423f7eafb523e695136f0a4e6ae4f0abec66848219ee6
@@ -3590,7 +3576,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-tree@npm:2.3.1, css-tree@npm:^2.3.1":
+"css-tree@npm:2.3.1":
   version: 2.3.1
   resolution: "css-tree@npm:2.3.1"
   dependencies:
@@ -3600,7 +3586,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-tree@npm:^3.2.1":
+"css-tree@npm:^3.1.0, css-tree@npm:^3.2.1":
   version: 3.2.1
   resolution: "css-tree@npm:3.2.1"
   dependencies:
@@ -3652,18 +3638,6 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/082c375a2bdc4f4469c99f325ff458adad62a3fc2c482d59923c260cb08152f34e2659f72b3767db8bb2f21ca81a60a42d1019605a412132d7b9f59363a005cc
-  languageName: node
-  linkType: hard
-
-"debug@npm:^4.3.6":
-  version: 4.3.6
-  resolution: "debug@npm:4.3.6"
-  dependencies:
-    ms: "npm:2.1.2"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 10c0/3293416bff072389c101697d4611c402a6bacd1900ac20c0492f61a9cdd6b3b29750fc7f5e299f8058469ef60ff8fb79b86395a30374fbd2490113c1c7112285
   languageName: node
   linkType: hard
 
@@ -4375,7 +4349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-entry-cache@npm:^11.1.3":
+"file-entry-cache@npm:^11.1.1, file-entry-cache@npm:^11.1.3":
   version: 11.1.3
   resolution: "file-entry-cache@npm:11.1.3"
   dependencies:
@@ -4390,15 +4364,6 @@ __metadata:
   dependencies:
     flat-cache: "npm:^4.0.0"
   checksum: 10c0/9e2b5938b1cd9b6d7e3612bdc533afd4ac17b2fc646569e9a8abbf2eb48e5eb8e316bc38815a3ef6a1b456f4107f0d0f055a614ca613e75db6bf9ff4d72c1638
-  languageName: node
-  linkType: hard
-
-"file-entry-cache@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "file-entry-cache@npm:9.0.0"
-  dependencies:
-    flat-cache: "npm:^5.0.0"
-  checksum: 10c0/07b0a4f062dc0aa258f3e1b06ac083ea25313f5e289943e146fafdaf3315dcc031635545eea7fe98fe5598b91d6c7f48dba7a251dd7ac20108a6ebf7d00b0b1c
   languageName: node
   linkType: hard
 
@@ -4441,16 +4406,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flat-cache@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "flat-cache@npm:5.0.0"
-  dependencies:
-    flatted: "npm:^3.3.1"
-    keyv: "npm:^4.5.4"
-  checksum: 10c0/847f25eefec5d6614fdce76dc6097ee98f63fd4dfbcb908718905ac56610f939f4c28b1f908d6e8857d49286fe73235095d2e7ac9df096c35a3e8a15204c361b
-  languageName: node
-  linkType: hard
-
 "flat-cache@npm:^6.1.22":
   version: 6.1.22
   resolution: "flat-cache@npm:6.1.22"
@@ -4462,7 +4417,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.2.9, flatted@npm:^3.3.1":
+"flatted@npm:^3.2.9":
   version: 3.3.1
   resolution: "flatted@npm:3.3.1"
   checksum: 10c0/324166b125ee07d4ca9bcf3a5f98d915d5db4f39d711fba640a3178b959919aae1f7cfd8aabcfef5826ed8aa8a2aa14cc85b2d7d18ff638ddf4ae3df39573eaf
@@ -4966,7 +4921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.1, ignore@npm:^5.3.2":
+"ignore@npm:^5.1.1":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
@@ -6031,6 +5986,13 @@ __metadata:
   version: 0.34.0
   resolution: "known-css-properties@npm:0.34.0"
   checksum: 10c0/8549969f02b1858554e89faf4548ece37625d0d21b42e8d54fa53184e68e1512ef2531bb15941575ad816361ab7447b598c1b18c1b96ce0a868333d1a68f2e2c
+  languageName: node
+  linkType: hard
+
+"known-css-properties@npm:^0.37.0":
+  version: 0.37.0
+  resolution: "known-css-properties@npm:0.37.0"
+  checksum: 10c0/e0ec08cae580e8833254b690971f73ec6f78ac461820a3c755b4a0b62c5b871501753b4aa60b30576a0f621ba44b231235cf9f35ab89e2e7de5448dfe0600241
   languageName: node
   linkType: hard
 
@@ -7209,15 +7171,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-safe-parser@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "postcss-safe-parser@npm:7.0.0"
-  peerDependencies:
-    postcss: ^8.4.31
-  checksum: 10c0/4217afd8ce2809e959dc365e4675f499303cc6b91f94db06c8164422822db2d3b3124df701ee2234db4127ad05619b016bfb9c2bccae9bf9cf898a396f1632c9
-  languageName: node
-  linkType: hard
-
 "postcss-safe-parser@npm:^7.0.1":
   version: 7.0.1
   resolution: "postcss-safe-parser@npm:7.0.1"
@@ -7256,7 +7209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-selector-parser@npm:^7.1.1":
+"postcss-selector-parser@npm:^7.1.0, postcss-selector-parser@npm:^7.1.1":
   version: 7.1.1
   resolution: "postcss-selector-parser@npm:7.1.1"
   dependencies:
@@ -7282,7 +7235,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.1.2, postcss@npm:^8.5.14":
+"postcss@npm:^8.1.2, postcss@npm:^8.5.14, postcss@npm:^8.5.6":
   version: 8.5.15
   resolution: "postcss@npm:8.5.15"
   dependencies:
@@ -7301,17 +7254,6 @@ __metadata:
     picocolors: "npm:^1.0.1"
     source-map-js: "npm:^1.2.0"
   checksum: 10c0/65ed67573e5443beaeb582282ff27a6be7c7fe3b4d9fa15761157616f2b97510cb1c335023c26220b005909f007337026d6e3ff092f25010b484ad484e80ea7f
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.4.41":
-  version: 8.4.45
-  resolution: "postcss@npm:8.4.45"
-  dependencies:
-    nanoid: "npm:^3.3.7"
-    picocolors: "npm:^1.0.1"
-    source-map-js: "npm:^1.2.0"
-  checksum: 10c0/ad6f8b9b1157d678560373696109745ab97a947d449f8a997acac41c7f1e4c0f3ca4b092d6df1387f430f2c9a319987b1780dbdc27e35800a88cde9b606c1e8f
   languageName: node
   linkType: hard
 
@@ -8147,51 +8089,51 @@ __metadata:
   linkType: hard
 
 "stylelint@npm:^16.8.2":
-  version: 16.9.0
-  resolution: "stylelint@npm:16.9.0"
+  version: 16.26.1
+  resolution: "stylelint@npm:16.26.1"
   dependencies:
-    "@csstools/css-parser-algorithms": "npm:^3.0.1"
-    "@csstools/css-tokenizer": "npm:^3.0.1"
-    "@csstools/media-query-list-parser": "npm:^3.0.1"
-    "@csstools/selector-specificity": "npm:^4.0.0"
-    "@dual-bundle/import-meta-resolve": "npm:^4.1.0"
+    "@csstools/css-parser-algorithms": "npm:^3.0.5"
+    "@csstools/css-syntax-patches-for-csstree": "npm:^1.0.19"
+    "@csstools/css-tokenizer": "npm:^3.0.4"
+    "@csstools/media-query-list-parser": "npm:^4.0.3"
+    "@csstools/selector-specificity": "npm:^5.0.0"
+    "@dual-bundle/import-meta-resolve": "npm:^4.2.1"
     balanced-match: "npm:^2.0.0"
     colord: "npm:^2.9.3"
     cosmiconfig: "npm:^9.0.0"
-    css-functions-list: "npm:^3.2.2"
-    css-tree: "npm:^2.3.1"
-    debug: "npm:^4.3.6"
-    fast-glob: "npm:^3.3.2"
+    css-functions-list: "npm:^3.2.3"
+    css-tree: "npm:^3.1.0"
+    debug: "npm:^4.4.3"
+    fast-glob: "npm:^3.3.3"
     fastest-levenshtein: "npm:^1.0.16"
-    file-entry-cache: "npm:^9.0.0"
+    file-entry-cache: "npm:^11.1.1"
     global-modules: "npm:^2.0.0"
     globby: "npm:^11.1.0"
     globjoin: "npm:^0.1.4"
     html-tags: "npm:^3.3.1"
-    ignore: "npm:^5.3.2"
+    ignore: "npm:^7.0.5"
     imurmurhash: "npm:^0.1.4"
     is-plain-object: "npm:^5.0.0"
-    known-css-properties: "npm:^0.34.0"
+    known-css-properties: "npm:^0.37.0"
     mathml-tag-names: "npm:^2.1.3"
     meow: "npm:^13.2.0"
     micromatch: "npm:^4.0.8"
     normalize-path: "npm:^3.0.0"
-    picocolors: "npm:^1.0.1"
-    postcss: "npm:^8.4.41"
+    picocolors: "npm:^1.1.1"
+    postcss: "npm:^8.5.6"
     postcss-resolve-nested-selector: "npm:^0.1.6"
-    postcss-safe-parser: "npm:^7.0.0"
-    postcss-selector-parser: "npm:^6.1.2"
+    postcss-safe-parser: "npm:^7.0.1"
+    postcss-selector-parser: "npm:^7.1.0"
     postcss-value-parser: "npm:^4.2.0"
     resolve-from: "npm:^5.0.0"
     string-width: "npm:^4.2.3"
-    strip-ansi: "npm:^7.1.0"
-    supports-hyperlinks: "npm:^3.1.0"
+    supports-hyperlinks: "npm:^3.2.0"
     svg-tags: "npm:^1.0.0"
-    table: "npm:^6.8.2"
+    table: "npm:^6.9.0"
     write-file-atomic: "npm:^5.0.1"
   bin:
     stylelint: bin/stylelint.mjs
-  checksum: 10c0/d3ff9c8945c56b04a2fa16ec33d163325496d5db94b6fcb5adf74c76f7f794ac992888273f9a3317652ba8b6195168b2ffff382ca2a667a241e2ace8c9505ae2
+  checksum: 10c0/3805dfe868abdcc5a62e5726eebe5e950432cfadfc5b47c2f103ef4dede8ee1eb8a1247c9ceb01a1739c0aba68865d79899d33a707256365bb2004664524908b
   languageName: node
   linkType: hard
 
@@ -8229,13 +8171,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-hyperlinks@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "supports-hyperlinks@npm:3.1.0"
+"supports-hyperlinks@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "supports-hyperlinks@npm:3.2.0"
   dependencies:
     has-flag: "npm:^4.0.0"
     supports-color: "npm:^7.0.0"
-  checksum: 10c0/78cc3e17eb27e6846fa355a8ebf343befe36272899cd409e45317a06c1997e95c23ff99d91080a517bd8c96508d4fa456e6ceb338c02ba5d7544277dbec0f10f
+  checksum: 10c0/bca527f38d4c45bc95d6a24225944675746c515ddb91e2456d00ae0b5c537658e9dd8155b996b191941b0c19036195a098251304b9082bbe00cd1781f3cd838e
   languageName: node
   linkType: hard
 
@@ -8269,19 +8211,6 @@ __metadata:
   dependencies:
     "@pkgr/core": "npm:^0.2.9"
   checksum: 10c0/f0761495953d12d94a86edf6326b3a565496c72f9b94c02549b6961fb4d999f4ca316ce6b3eb8ed2e4bfc5056a8de65cda0bd03a233333a35221cd2fdc0e196b
-  languageName: node
-  linkType: hard
-
-"table@npm:^6.8.2":
-  version: 6.8.2
-  resolution: "table@npm:6.8.2"
-  dependencies:
-    ajv: "npm:^8.0.1"
-    lodash.truncate: "npm:^4.4.2"
-    slice-ansi: "npm:^4.0.0"
-    string-width: "npm:^4.2.3"
-    strip-ansi: "npm:^6.0.1"
-  checksum: 10c0/f8b348af38ee34e419d8ce7306ba00671ce6f20e861ccff22555f491ba264e8416086063ce278a8d81abfa8d23b736ec2cca7ac4029b5472f63daa4b4688b803
   languageName: node
   linkType: hard
 
@@ -8397,6 +8326,15 @@ __metadata:
   peerDependencies:
     typescript: ">=4.2.0"
   checksum: 10c0/f54a0ba9ed56ce66baea90a3fa087a484002e807f28a8ccb2d070c75e76bde64bd0f6dce98b3802834156306050871b67eec325cb4e918015a360a3f0868c77c
+  languageName: node
+  linkType: hard
+
+"ts-jest-mock-import-meta@npm:1.3.2":
+  version: 1.3.2
+  resolution: "ts-jest-mock-import-meta@npm:1.3.2"
+  peerDependencies:
+    ts-jest: ">=20.0.0"
+  checksum: 10c0/e910919b0965e2a554e96981121572153b5e6fc090444b171e406502553b2609e9e69d51d25b41480af09504831676799bd7bd2a7bdf7308f895b65e6843bff1
   languageName: node
   linkType: hard
 
@@ -8962,6 +8900,7 @@ __metadata:
     stylelint-order: "npm:6.0.4"
     stylelint-scss: "npm:6.5.1"
     ts-jest: "npm:29.4.11"
+    ts-jest-mock-import-meta: "npm:1.3.2"
     ts-node: "npm:10.9.2"
     tslib: "npm:2.7.0"
     tsx: "npm:4.19.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,6 +2580,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/postcss-less@npm:4.0.7":
+  version: 4.0.7
+  resolution: "@types/postcss-less@npm:4.0.7"
+  dependencies:
+    postcss: "npm:^8.1.2"
+  checksum: 10c0/c7f0c0078bfa35879c498e90f269a2bec0b28834173cec70f2f1a248965b59b81ff541f9660cd8e80554072bc6b1153992637f967e74984b27a69ec80cb5a7c9
+  languageName: node
+  linkType: hard
+
 "@types/resolve@npm:1.20.2":
   version: 1.20.2
   resolution: "@types/resolve@npm:1.20.2"
@@ -7273,6 +7282,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:^8.1.2, postcss@npm:^8.5.14":
+  version: 8.5.15
+  resolution: "postcss@npm:8.5.15"
+  dependencies:
+    nanoid: "npm:^3.3.12"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
+  languageName: node
+  linkType: hard
+
 "postcss@npm:^8.4.32":
   version: 8.4.40
   resolution: "postcss@npm:8.4.40"
@@ -7292,17 +7312,6 @@ __metadata:
     picocolors: "npm:^1.0.1"
     source-map-js: "npm:^1.2.0"
   checksum: 10c0/ad6f8b9b1157d678560373696109745ab97a947d449f8a997acac41c7f1e4c0f3ca4b092d6df1387f430f2c9a319987b1780dbdc27e35800a88cde9b606c1e8f
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.14":
-  version: 8.5.15
-  resolution: "postcss@npm:8.5.15"
-  dependencies:
-    nanoid: "npm:^3.3.12"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
   languageName: node
   linkType: hard
 
@@ -8923,6 +8932,7 @@ __metadata:
     "@types/eslint": "npm:9.6.1"
     "@types/jest": "npm:30.0.0"
     "@types/node-notifier": "npm:8.0.5"
+    "@types/postcss-less": "npm:4.0.7"
     chalk: "npm:5.6.2"
     chokidar: "npm:3.6.0"
     commander: "npm:12.1.0"


### PR DESCRIPTION
## Details

### What have you changed?

- ⬆️ Upgraded Stylelint from v16.9.0 to v17.12.0.

- 🎉 Added custom or default Stylelint config loading functionality.
  - Implemented `resolveConfigFile` to detect and use custom configs via `stylelint.resolveConfig`.
  - Falls back to the default config when no custom config exists.

- ⚠️ Added support for warning-level violations in markdownlint results.

- 👍 Corrected imports and mock names in test files for consistency.

- 🛂 Updated minimum Node.js version from `>=20` to `>=20.19` in CI and package config.

### Why are you making these changes?

- ⬆️ Stylelint v17 brings improvements, new features, and security updates.

- 🎉 This allows users to define their own Stylelint rules while providing a sensible default.
  - Custom configs are auto-discovered by Stylelint when present.
  - The default config ensures linting works out of the box.

- ⚠️ This accurately reports warnings separately from errors, aligning with how other linters behave.

- 👍 Consistent naming improves readability and maintains code quality standards.

- 🛂 Node.js 20.19 is required for compatibility with Stylelint v17's dependencies.