### PR TITLE
Error handling, and test quality improvements 🔧

### DIFF
--- a/jest-config/setup.ts
+++ b/jest-config/setup.ts
@@ -55,7 +55,9 @@ afterEach(() => {
 expect.extend({
   toHaveBeenCalledOnceWith(received, ...expected) {
     const calls = received.mock.calls
-    const pass = calls.length === 1 && expected.every((arg, index) => this.equals(calls[0]?.[index], arg))
+    const pass = calls.length === 1
+      && expected.every((arg, index) => this.equals(calls[0]?.[index], arg))
+      && calls[0].length === expected.length
 
     const printExpected = this.utils.printExpected(expected)
     const printReceived = this.utils.printReceived(calls[0])

--- a/knip.json
+++ b/knip.json
@@ -16,7 +16,6 @@
   "entry": [
     "config/all-legacy.ts",
     "config/all.ts",
-    "config/stylelint.config.ts",
-    "src/index.ts"
+    "config/stylelint.config.ts"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@rollup/plugin-typescript": "12.3.0",
     "@types/eslint": "9.6.1",
     "@types/jest": "30.0.0",
+    "@types/node": "20.19.42",
     "@types/node-notifier": "8.0.5",
     "@types/postcss-less": "4.0.7",
     "jest": "30.4.2",

--- a/src/linters/markdownlint/__tests__/fix-file.spec.ts
+++ b/src/linters/markdownlint/__tests__/fix-file.spec.ts
@@ -34,4 +34,11 @@ describe('fixFile', () => {
     expect(writeFileSync).toHaveBeenCalledWith(path.join(process.cwd(), filePath), fixedFileContent)
   })
 
+  it('throws an error if reading the file fails', () => {
+    const error = new Error('Failed to read file')
+    jest.mocked(readFileSync).mockImplementation(() => { throw error })
+
+    expect(() => fixFile({ errors: [markdownlintError], file: 'test.md' })).toThrow('Failed to fix test.md')
+  })
+
 })

--- a/src/linters/markdownlint/fix-file.ts
+++ b/src/linters/markdownlint/fix-file.ts
@@ -12,10 +12,14 @@ interface FixFileOptions {
 
 const fixFile = ({ errors, file }: FixFileOptions): void => {
   const filePath = path.join(process.cwd(), file)
-  const fileContent = readFileSync(filePath, 'utf8')
-  const fixedContent = applyFixes(fileContent, errors)
 
-  writeFileSync(filePath, fixedContent)
+  try {
+    const fileContent = readFileSync(filePath, 'utf8')
+    const fixedContent = applyFixes(fileContent, errors)
+    writeFileSync(filePath, fixedContent)
+  } catch (error) {
+    throw new Error(`Failed to fix ${file}`, { cause: error })
+  }
 }
 
 export {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2816,6 +2816,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:20.19.42":
+  version: 20.19.42
+  resolution: "@types/node@npm:20.19.42"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/e21d8ee6e45480688b933fd6d61c1e538efff5cbd88e3bd737fba4d41511ab0904ad5b5a86d3fe5977984496f51d25f7304c8652f5a0efdb6a44ec9458dd6b74
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^12.7.1":
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
@@ -8723,6 +8732,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
+  languageName: node
+  linkType: hard
+
 "unicorn-magic@npm:^0.4.0":
   version: 0.4.0
   resolution: "unicorn-magic@npm:0.4.0"
@@ -9089,6 +9105,7 @@ __metadata:
     "@stylistic/stylelint-plugin": "npm:3.1.3"
     "@types/eslint": "npm:9.6.1"
     "@types/jest": "npm:30.0.0"
+    "@types/node": "npm:20.19.42"
     "@types/node-notifier": "npm:8.0.5"
     "@types/postcss-less": "npm:4.0.7"
     chalk: "npm:5.6.2"


### PR DESCRIPTION
## Details

### What have you changed?

- 📦 Added `@types/node` as a direct devDependency, pinned to `20.19.42` to match the minimum supported Node.js version.

- 🗂️ Removed `src/index.ts` from knip's explicit `entry` configuration — knip auto-detects it through `package.json`.

- 🛡️ Wrapped `readFileSync` and `writeFileSync` in `fix-file.ts` with a try/catch that re-throws with the filename as context, providing a clearer error message when a markdown file cannot be fixed.

- 🔧 Fixed `toHaveBeenCalledOnceWith` custom matcher to also assert argument count, preventing false positives when a mock is called with extra unexpected arguments.

### Why are you making these changes?

- 📦 `@types/node` was previously resolved only transitively; declaring it directly makes the dependency explicit and pins it to the minimum supported Node.js version (`20.19`), ensuring TypeScript catches any use of APIs unavailable to consumers on that version.

- 🗂️ Removes redundancy — knip's built-in entry point detection covers `src/index.ts` via `package.json`.

- 🛡️ Without context, a file operation failure would surface as a generic markdownlint error, making it difficult to identify which file caused the problem.

- 🔧 The previous implementation checked argument values by index but not argument count — a mock called with extra arguments would pass the assertion when it should fail.